### PR TITLE
Provide local accessor for `bson_t.len`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+.vscode

--- a/libbson.h
+++ b/libbson.h
@@ -1,2 +1,8 @@
 #define BCON_H_
 #include <bson.h>
+
+uint32_t _bson_get_len(const bson_t *bson)
+{
+    BSON_ASSERT (bson);
+    return bson->len;
+}


### PR DESCRIPTION
In Swift 5, `bson_t` is treated as an `OpaquePointer` so we no
longer have type information for its fields. This allows us to
retrieve the `len` field by providing a custom accessor.