### PR TITLE
SWIFT-837 Add API sketch required for SWIFT-841

### DIFF
--- a/Sources/BSON/BSON.swift
+++ b/Sources/BSON/BSON.swift
@@ -1,3 +1,92 @@
+import Foundation
+
 /// Enum representing a BSON value.
 /// - SeeAlso: bsonspec.org
-public enum BSON {}
+public enum BSON {
+    /// A BSON document.
+    case document(Document)
+
+    /// A BSON int32.
+    case int32(Int32)
+
+    /// A BSON int64.
+    case int64(Int64)
+
+    /// Initialize a `BSON` from an integer. On 64-bit systems, this will result in an `.int64`. On 32-bit systems,
+    /// this will result in an `.int32`.
+    public init(_ int: Int) {
+        if MemoryLayout<Int>.size == 4 {
+            self = .int32(Int32(int))
+        } else {
+            self = .int64(Int64(int))
+        }
+    }
+
+    /// Get the `BSONType` of this `BSON`.
+    public var type: BSONType {
+        self.bsonValue.bsonType
+    }
+
+    /// If this `BSON` is an `.int32`, return it as an `Int32`. Otherwise, return nil.
+    public var int32Value: Int32? {
+        guard case let .int32(i) = self else {
+            return nil
+        }
+        return i
+    }
+
+    /// If this `BSON` is an `.int64`, return it as an `Int64`. Otherwise, return nil.
+    public var int64Value: Int64? {
+        guard case let .int64(i) = self else {
+            return nil
+        }
+        return i
+    }
+
+    /// If this `BSON` is a `.document`, return it as a `Document`. Otherwise, return nil.
+    public var documentValue: Document? {
+        guard case let .document(d) = self else {
+            return nil
+        }
+        return d
+    }
+}
+
+/// Extension providing the internal API of `BSON`
+extension BSON {
+    /// List of all BSONValue types. Can be used to exhaustively check each one at runtime.
+    internal static var allBSONTypes: [BSONValue.Type] = [
+        Document.self,
+        Int32.self,
+        Int64.self
+    ]
+
+    /// Get the associated `BSONValue` to this `BSON` case.
+    internal var bsonValue: BSONValue {
+        switch self {
+        case let .document(v):
+            return v
+        case let .int32(v):
+            return v
+        case let .int64(v):
+            return v
+        }
+    }
+}
+
+extension BSON: ExpressibleByIntegerLiteral {
+    /// Initialize a `BSON` from an integer. On 64-bit systems, this will result in an `.int64`. On 32-bit systems,
+    /// this will result in an `.int32`.
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+}
+
+extension BSON: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, BSON)...) {
+        self = .document(Document(keyValuePairs: elements))
+    }
+}
+
+extension BSON: Equatable {}
+extension BSON: Hashable {}

--- a/Sources/BSON/BSONValue.swift
+++ b/Sources/BSON/BSONValue.swift
@@ -1,6 +1,6 @@
 import NIO
 
-internal protocol BSONValue: Codable {
+internal protocol BSONValue {
     /// The `BSONType` associated with this value.
     var bsonType: BSONType { get }
 
@@ -63,4 +63,34 @@ public enum BSONType: UInt32 {
     case minKey = 0xFF
     /// Special type which compares higher than all other possible BSON element values
     case maxKey = 0x7F
+}
+
+// Conformances of Swift types we don't own to BSONValue:
+
+extension Int32: BSONValue {
+    var bsonType: BSONType { fatalError("Unimplemented") }
+
+    var bson: BSON { fatalError("Unimplemented") }
+
+    static func read(from buffer: inout ByteBuffer) throws -> BSON {
+        fatalError("Unimplemented")
+    }
+
+    func write(to buffer: inout ByteBuffer) throws {
+        fatalError("Unimplemented")
+    }
+}
+
+extension Int64: BSONValue {
+    var bsonType: BSONType { fatalError("Unimplemented") }
+
+    var bson: BSON { fatalError("Unimplemented") }
+
+    static func read(from buffer: inout ByteBuffer) throws -> BSON {
+        fatalError("Unimplemented")
+    }
+
+    func write(to buffer: inout ByteBuffer) throws {
+        fatalError("Unimplemented")
+    }
 }

--- a/Sources/BSON/Document.swift
+++ b/Sources/BSON/Document.swift
@@ -50,9 +50,9 @@ public struct Document {
     /// The number of (key, value) pairs stored at the top level of this document.
     public var count: Int { fatalError("Unimplemented") }
 
-    /// A copy of the `ByteBuffer` backing this document, containing raw BSON data.
-    /// As `ByteBuffer`s implement copy-on-write, this copy will share byte storage with
-    /// this document until either the document or the returned buffer is mutated.
+    /// A copy of the `ByteBuffer` backing this document, containing raw BSON data. As `ByteBuffer`s implement
+    /// copy-on-write, this copy will share byte storage with this document until either the document or the returned
+    /// buffer is mutated.
     public var buffer: ByteBuffer { fatalError("Unimplemented") }
 
     /// Returns a `Data` containing a copy of the raw BSON data backing this document.
@@ -69,8 +69,8 @@ public struct Document {
      *  d["a"] = 1
      *  print(d["a"]) // prints 1
      *  ```
-     * A nil return value indicates that the key does not exist in the  `Document`.
-     * A true BSON null is returned as `BSON.null`.
+     * A nil return value indicates that the key does not exist in the  `Document`. A true BSON null is returned as
+     * `BSON.null`.
      */
     public subscript(key: String) -> BSON? {
         get { fatalError("Unimplemented") }

--- a/Sources/BSON/Document.swift
+++ b/Sources/BSON/Document.swift
@@ -1,0 +1,153 @@
+import Foundation
+import NIO
+
+/// A struct representing the BSON document type.
+@dynamicMemberLookup
+public struct Document {
+    /// The element type of a document: a tuple containing an individual key-value pair.
+    public typealias KeyValuePair = (key: String, value: BSON)
+
+    private var _buffer: ByteBuffer
+
+    /// An unordered set containing the keys in this document.
+    private var keySet: Set<String>
+
+    internal init(_ elements: [BSON]) { fatalError("Unimplemented") }
+
+    internal init(keyValuePairs: [(String, BSON)]) { fatalError("Unimplemented") }
+
+    /// Initializes a new, empty `Document`.
+    public init() { fatalError("Unimplemented") }
+
+    /**
+     * Initializes a new `Document` from the provided BSON data. If validate is `true` (the default), validates that
+     * the data is specification-compliant BSON.
+     *
+     * - Throws:
+     *   - `InvalidArgumentError` if the data passed is invalid BSON
+     *
+     * - SeeAlso: http://bsonspec.org/
+     */
+    public init(fromBSON bson: Data, validate: Bool = true) throws { fatalError("Unimplemented") }
+
+    /**
+     * Initializes a new `Document` from the provided BSON data. If validate is `true` (the default), validates that
+     * the data is specification-compliant BSON.
+     *
+     * - Throws:
+     *   - `InvalidArgumentError` if the data passed is invalid BSON
+     *
+     * - SeeAlso: http://bsonspec.org/
+     */
+    public init(fromBSON bson: ByteBuffer, validate: Bool = true) throws { fatalError("Unimplemented") }
+
+    /// The keys in this `Document`.
+    public var keys: [String] { fatalError("Unimplemented") }
+
+    /// The values in this `Document`.
+    public var values: [BSON] { fatalError("Unimplemented") }
+
+    /// The number of (key, value) pairs stored at the top level of this document.
+    public var count: Int { fatalError("Unimplemented") }
+
+    /// A copy of the `ByteBuffer` backing this document, containing raw BSON data.
+    /// As `ByteBuffer`s implement copy-on-write, this copy will share byte storage with
+    /// this document until either the document or the returned buffer is mutated.
+    public var buffer: ByteBuffer { fatalError("Unimplemented") }
+
+    /// Returns a `Data` containing a copy of the raw BSON data backing this document.
+    public func toData() -> Data { fatalError("Unimplemented") }
+
+    /// Returns a `Boolean` indicating whether this `Document` contains the provided key.
+    public func hasKey(_ key: String) -> Bool { fatalError("Unimplemented") }
+
+    /**
+     * Allows getting and setting values on the document via subscript syntax.
+     * For example:
+     *  ```
+     *  let d = Document()
+     *  d["a"] = 1
+     *  print(d["a"]) // prints 1
+     *  ```
+     * A nil return value indicates that the key does not exist in the  `Document`.
+     * A true BSON null is returned as `BSON.null`.
+     */
+    public subscript(key: String) -> BSON? {
+        get { fatalError("Unimplemented") }
+        set { fatalError("Unimplemented") }
+    }
+
+    /**
+     * Looks up the specified key in the document and returns its corresponding value, or returns `defaultValue` if the
+     * key is not present.
+     *
+     * For example:
+     *  ```
+     *  let d: Document = ["hello": "world"]
+     *  print(d["hello", default: "foo"]) // prints "world"
+     *  print(d["a", default: "foo"]) // prints "foo"
+     *  ```
+     */
+    public subscript(key: String, default defaultValue: @autoclosure () -> BSON) -> BSON {
+        fatalError("Unimplemented")
+    }
+
+    /**
+     * Allows getting and setting values on the document using dot-notation syntax.
+     * For example:
+     *  ```
+     *  let d = Document()
+     *  d.a = 1
+     *  print(d.a) // prints 1
+     *  ```
+     * A nil return value indicates that the key does not exist in the `Document`.
+     * A true BSON null is returned as `BSON.null`.
+     */
+    public subscript(dynamicMember member: String) -> BSON? {
+        get { fatalError("Unimplemented") }
+        set { fatalError("Unimplemented") }
+    }
+}
+
+/// An extension of `Document` to add the capability to be initialized with a dictionary literal.
+extension Document: ExpressibleByDictionaryLiteral {
+    /**
+     * Initializes a `Document` using a dictionary literal where the keys are `Strings` and the values are `BSON`s.
+     * For example:
+     * `d: Document = ["a" : 1 ]`
+     *
+     * - Parameters:
+     *   - dictionaryLiteral: a [String: BSON]
+     *
+     * - Returns: a new `Document`
+     */
+    public init(dictionaryLiteral keyValuePairs: (String, BSON)...) {
+        fatalError("Unimplemented")
+    }
+}
+
+extension Document: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        fatalError("Unimplemented")
+    }
+}
+
+extension Document: Equatable {
+    public static func == (lhs: Document, rhs: Document) -> Bool {
+        fatalError("Unimplemented")
+    }
+}
+
+extension Document: BSONValue {
+    var bsonType: BSONType { fatalError("Unimplemented") }
+
+    var bson: BSON { fatalError("Unimplemented") }
+
+    static func read(from buffer: inout ByteBuffer) throws -> BSON {
+        fatalError("Unimplemented")
+    }
+
+    func write(to buffer: inout ByteBuffer) throws {
+        fatalError("Unimplemented")
+    }
+}

--- a/Sources/BSON/Document.swift
+++ b/Sources/BSON/Document.swift
@@ -20,26 +20,24 @@ public struct Document {
     public init() { fatalError("Unimplemented") }
 
     /**
-     * Initializes a new `Document` from the provided BSON data. If validate is `true` (the default), validates that
-     * the data is specification-compliant BSON.
+     * Initializes a new `Document` from the provided BSON data.
      *
      * - Throws:
      *   - `InvalidArgumentError` if the data passed is invalid BSON
      *
      * - SeeAlso: http://bsonspec.org/
      */
-    public init(fromBSON bson: Data, validate: Bool = true) throws { fatalError("Unimplemented") }
+    public init(fromBSON bson: Data) throws { fatalError("Unimplemented") }
 
     /**
-     * Initializes a new `Document` from the provided BSON data. If validate is `true` (the default), validates that
-     * the data is specification-compliant BSON.
+     * Initializes a new `Document` from the provided BSON data.
      *
      * - Throws:
      *   - `InvalidArgumentError` if the data passed is invalid BSON
      *
      * - SeeAlso: http://bsonspec.org/
      */
-    public init(fromBSON bson: ByteBuffer, validate: Bool = true) throws { fatalError("Unimplemented") }
+    public init(fromBSON bson: ByteBuffer) throws { fatalError("Unimplemented") }
 
     /// The keys in this `Document`.
     public var keys: [String] { fatalError("Unimplemented") }

--- a/Sources/BSON/DocumentIterator.swift
+++ b/Sources/BSON/DocumentIterator.swift
@@ -37,9 +37,9 @@ public struct DocumentIterator: IteratorProtocol {
 }
 
 extension Document {
-    // this is an alternative to the built-in `Document.filter` that returns an `[KeyValuePair]`.
-    // this variant is called by default, but the other is still accessible by explicitly stating
-    // return type: `let newDocPairs: [Document.KeyValuePair] = newDoc.filter { ... }`
+    // this is an alternative to the built-in `Document.filter` that returns an `[KeyValuePair]`. this variant is
+    // called by default, but the other is still accessible by explicitly stating return type:
+    // `let newDocPairs: [Document.KeyValuePair] = newDoc.filter { ... }`
     /**
      * Returns a new document containing the elements of the document that satisfy the given predicate.
      *

--- a/Sources/BSON/DocumentIterator.swift
+++ b/Sources/BSON/DocumentIterator.swift
@@ -1,0 +1,57 @@
+import Foundation
+import NIO
+
+extension Document: Sequence {
+    // Since a `Document` is a recursive structure, we want to enforce the use of it as a subsequence of itself,
+    // instead of something like `Slice<Document>`.
+    /// The type that is returned from methods such as `dropFirst()` and `split()`.
+    public typealias SubSequence = Document
+
+    /// Returns a `Bool` indicating whether the document is empty.
+    public var isEmpty: Bool { fatalError("Unimplemented") }
+
+    /// Returns a `DocumentIterator` over the values in this `Document`.
+    public func makeIterator() -> DocumentIterator {
+        fatalError("Unimplemented")
+    }
+}
+
+public struct DocumentIterator: IteratorProtocol {
+    /// The buffer we are iterating over.
+    private var buffer: ByteBuffer
+
+    internal init(over buffer: ByteBuffer) {
+        fatalError("Unimplemented")
+    }
+
+    /// Advances to the next element and returns it, or nil if no next element exists.
+    public mutating func next() -> (String, BSON)? {
+        fatalError("Unimplemented")
+    }
+
+    /// Finds the key in the underlying buffer, and returns the [startIndex, endIndex) containing the corresponding
+    /// element.
+    internal func findByteRange(for key: String) -> (startIndex: Int, endIndex: Int) {
+        fatalError("Unimplemented")
+    }
+}
+
+extension Document {
+    // this is an alternative to the built-in `Document.filter` that returns an `[KeyValuePair]`.
+    // this variant is called by default, but the other is still accessible by explicitly stating
+    // return type: `let newDocPairs: [Document.KeyValuePair] = newDoc.filter { ... }`
+    /**
+     * Returns a new document containing the elements of the document that satisfy the given predicate.
+     *
+     * - Parameters:
+     *   - isIncluded: A closure that takes a key-value pair as its argument and returns a `Bool` indicating whether
+     *                 the pair should be included in the returned document.
+     *
+     * - Returns: A document containing the key-value pairs that `isIncluded` allows.
+     *
+     * - Throws: An error if `isIncluded` throws an error.
+     */
+    public func filter(_ isIncluded: (KeyValuePair) throws -> Bool) rethrows -> Document {
+        fatalError("Unimplemented")
+    }
+}


### PR DESCRIPTION
Forgot I hadn't included this in the last PR, but this should include enough skeleton to get Neal rolling on SWIFT-841 which is adding support for reading and writing integer types and nested documents.

This is all just copying API sketch from driver/design doc. Where possible I left in existing implementations of methods from the driver.

Also I left out Codable conformance for now / removed `BSONValue`'s inheritance from `Codable`, but I'm going to open a new ticket in the epic about adding that back and copyingover conformances + BSONEncoder and BSONDecoder.