### PR TITLE
SWIFT-868,SWIFT-867,SWIFT-866: Mutable Valid BSONDocument

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "72f5a90d573f7f7d70aa6b8ad84b3e1e02eabb4d",
-          "version": "8.0.9"
+          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
+          "version": "8.1.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "c5fa0b456524cd73dc3ddbb263d4f46c20b86ca3",
-          "version": "2.17.0"
+          "revision": "120acb15c39aa3217e9888e515de160378fbcc1e",
+          "version": "2.18.0"
         }
       }
     ]

--- a/Sources/BSON/BSON.swift
+++ b/Sources/BSON/BSON.swift
@@ -31,7 +31,7 @@ public enum BSON {
 /// Value getters
 extension BSON {
     /// If this `BSON` is an `.int32`, return it as an `Int32`. Otherwise, return nil.
-    var int32Value: Int32? {
+    public var int32Value: Int32? {
         guard case let .int32(i) = self else {
             return nil
         }
@@ -39,7 +39,7 @@ extension BSON {
     }
 
     /// If this `BSON` is an `.int64`, return it as an `Int64`. Otherwise, return nil.
-    var int64Value: Int64? {
+    public var int64Value: Int64? {
         guard case let .int64(i) = self else {
             return nil
         }
@@ -47,7 +47,7 @@ extension BSON {
     }
 
     /// If this `BSON` is a `.document`, return it as a `BSONDocument`. Otherwise, return nil.
-    var documentValue: BSONDocument? {
+    public var documentValue: BSONDocument? {
         guard case let .document(d) = self else {
             return nil
         }

--- a/Sources/BSON/BSON.swift
+++ b/Sources/BSON/BSON.swift
@@ -31,7 +31,7 @@ public enum BSON {
 /// Value getters
 extension BSON {
     /// If this `BSON` is an `.int32`, return it as an `Int32`. Otherwise, return nil.
-    public var int32Value: Int32? {
+    var int32Value: Int32? {
         guard case let .int32(i) = self else {
             return nil
         }
@@ -39,7 +39,7 @@ extension BSON {
     }
 
     /// If this `BSON` is an `.int64`, return it as an `Int64`. Otherwise, return nil.
-    public var int64Value: Int64? {
+    var int64Value: Int64? {
         guard case let .int64(i) = self else {
             return nil
         }
@@ -47,7 +47,7 @@ extension BSON {
     }
 
     /// If this `BSON` is a `.document`, return it as a `BSONDocument`. Otherwise, return nil.
-    public var documentValue: BSONDocument? {
+    var documentValue: BSONDocument? {
         guard case let .document(d) = self else {
             return nil
         }

--- a/Sources/BSON/BSONDocument.swift
+++ b/Sources/BSON/BSONDocument.swift
@@ -93,7 +93,8 @@ public struct BSONDocument {
      * Initializes a new `BSONDocument` from the provided BSON data.
      *
      * - Throws:
-     *   - `InvalidArgumentError` if the data passed is invalid BSON
+     *   - `InvalidArgumentError` if the data passed is invalid BSON,
+     *      ByteBuffer must have `readableBytes` equal to the BSON's leading size indicator
      *
      * - SeeAlso: http://bsonspec.org/
      */

--- a/Sources/BSON/BSONDocumentIterator.swift
+++ b/Sources/BSON/BSONDocumentIterator.swift
@@ -67,18 +67,18 @@ public struct BSONDocumentIterator: IteratorProtocol {
 
     /// Finds the key in the underlying buffer, and returns the [startIndex, endIndex) containing the corresponding
     /// element.
-    internal func findByteRange(for searchKey: String) -> (startIndex: Int, length: Int)? {
+    internal func findByteRange(for searchKey: String) -> (startIndex: Int, endIndex: Int)? {
         var iter = BSONDocumentIterator(over: self.buffer)
         while true {
-            let starterIndex = iter.buffer.readerIndex
+            let startIndex = iter.buffer.readerIndex
             guard let (key, _) = iter.next() else {
                 // Iteration ended without finding a match
                 return nil
             }
-            let enderIndex = iter.buffer.readerIndex
+            let endIndex = iter.buffer.readerIndex
 
             if key == searchKey {
-                return (startIndex: starterIndex, length: enderIndex - starterIndex)
+                return (startIndex: startIndex, endIndex: endIndex)
             }
         }
     }

--- a/Sources/BSON/BSONDocumentIterator.swift
+++ b/Sources/BSON/BSONDocumentIterator.swift
@@ -28,13 +28,25 @@ public struct BSONDocumentIterator: IteratorProtocol {
 
     /// Advances to the next element and returns it, or nil if no next element exists.
     public mutating func next() -> BSONDocument.KeyValuePair? {
+        do {
+            return try self._next()
+        } catch {
+            fatalError("\(error)")
+        }
+    }
+
+    /**
+     * Advances to the next element and returns it, or nil if no next element exists.
+     * - Throws:
+     */
+    private mutating func _next() throws -> BSONDocument.KeyValuePair? {
         guard self.buffer.readableBytes != 0 else {
             // Iteration has been exhausted
             return nil
         }
 
         guard let typeByte = self.buffer.readInteger(as: UInt8.self) else {
-            fatalError("BSONDocumentIterator Failed: Cannot read from \(self.buffer)")
+            throw BSONError.InternalError(message: "BSONDocumentIterator Failed: Cannot read from \(self.buffer)")
         }
 
         guard typeByte != 0 else {
@@ -43,31 +55,39 @@ public struct BSONDocumentIterator: IteratorProtocol {
         }
 
         guard let type = BSONType(rawValue: typeByte), type != .invalid else {
-            fatalError("BSONDocumentIterator Failed: Invalid type, \(typeByte)")
+            throw BSONError.InternalError(message: "BSONDocumentIterator Failed: Invalid type, \(typeByte)")
         }
 
-        do {
-            let key = try self.buffer.readCString()
-            guard let bson = try BSON.allBSONTypes[type]?.read(from: &buffer) else {
-                throw BSONError.InternalError(message: "Cannot read unknown type: \(type)")
-            }
-            return (key: key, value: bson)
-        } catch {
-            fatalError("BSONDocumentIterator.next() failed: \(error)")
+        let key = try self.buffer.readCString()
+        guard let bson = try BSON.allBSONTypes[type]?.read(from: &buffer) else {
+            throw BSONError.InternalError(message: "Cannot read unknown type: \(type)")
         }
+        return (key: key, value: bson)
     }
 
     /// Finds the key in the underlying buffer, and returns the [startIndex, endIndex) containing the corresponding
     /// element.
-    internal func findByteRange(for key: String) -> (startIndex: Int, endIndex: Int) {
-        fatalError("Unimplemented")
+    internal func findByteRange(for searchKey: String) -> (startIndex: Int, length: Int)? {
+        var iter = BSONDocumentIterator(over: self.buffer)
+        while true {
+            let starterIndex = iter.buffer.readerIndex
+            guard let (key, _) = iter.next() else {
+                // Iteration ended without finding a match
+                return nil
+            }
+            let enderIndex = iter.buffer.readerIndex
+
+            if key == searchKey {
+                return (startIndex: starterIndex, length: enderIndex - starterIndex)
+            }
+        }
     }
 }
 
 extension BSONDocument {
-    // this is an alternative to the built-in `Document.filter` that returns an `[KeyValuePair]`. this variant is
+    // this is an alternative to the built-in `BSONDocument.filter` that returns an `[KeyValuePair]`. this variant is
     // called by default, but the other is still accessible by explicitly stating return type:
-    // `let newDocPairs: [Document.KeyValuePair] = newDoc.filter { ... }`
+    // `let newDocPairs: [BSONDocument.KeyValuePair] = newDoc.filter { ... }`
     /**
      * Returns a new document containing the elements of the document that satisfy the given predicate.
      *
@@ -80,6 +100,10 @@ extension BSONDocument {
      * - Throws: An error if `isIncluded` throws an error.
      */
     public func filter(_ isIncluded: (KeyValuePair) throws -> Bool) rethrows -> BSONDocument {
-        fatalError("Unimplemented")
+        var elements: [BSONDocument.KeyValuePair] = []
+        for pair in self where try isIncluded(pair) {
+            elements.append(pair)
+        }
+        return BSONDocument(keyValuePairs: elements)
     }
 }

--- a/Sources/BSON/BSONDocumentIterator.swift
+++ b/Sources/BSON/BSONDocumentIterator.swift
@@ -39,7 +39,7 @@ public struct BSONDocumentIterator: IteratorProtocol {
      * Advances to the next element and returns it, or nil if no next element exists.
      * - Throws:
      */
-    private mutating func _next() throws -> BSONDocument.KeyValuePair? {
+    internal mutating func _next() throws -> BSONDocument.KeyValuePair? {
         guard self.buffer.readableBytes != 0 else {
             // Iteration has been exhausted
             return nil

--- a/Sources/BSON/BSONError.swift
+++ b/Sources/BSON/BSONError.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIO
 
 /// An empty protocol for encapsulating all errors that BSON package can throw.
 public protocol BSONErrorProtocol: LocalizedError {}
@@ -39,4 +40,28 @@ public enum BSONError {
                 " BSON type \(value.bsonType): document too large"
         }
     }
+}
+
+internal func BSONIterationError(
+    buffer: ByteBuffer? = nil,
+    key: String? = nil,
+    type: BSONType? = nil,
+    typeByte: UInt8? = nil,
+    message: String
+) -> BSONError.InternalError {
+    var error = "BSONDocument Iteration Failed:"
+    if let buffer = buffer {
+        error += " at \(buffer.readerIndex)"
+    }
+    if let key = key {
+        error += " for \"\(key)\""
+    }
+    if let type = type {
+        error += " as \(type)"
+    }
+    if let typeByte = typeByte {
+        error += " (type: 0x\(String(typeByte, radix: 16).uppercased()))"
+    }
+    error += " \(message)"
+    return BSONError.InternalError(message: error)
 }

--- a/Sources/BSON/BSONError.swift
+++ b/Sources/BSON/BSONError.swift
@@ -42,6 +42,8 @@ public enum BSONError {
     }
 }
 
+/// Standardize the error's emitted from the BSON Iterator
+/// the BSON iterator is used for validation so this should help debug the underlying incorrect binary
 internal func BSONIterationError(
     buffer: ByteBuffer? = nil,
     key: String? = nil,
@@ -54,7 +56,7 @@ internal func BSONIterationError(
         error += " at \(buffer.readerIndex)"
     }
     if let key = key {
-        error += " for \"\(key)\""
+        error += " for '\(key)'"
     }
     if let type = type {
         error += " as \(type)"

--- a/Sources/BSON/BSONError.swift
+++ b/Sources/BSON/BSONError.swift
@@ -42,8 +42,8 @@ public enum BSONError {
     }
 }
 
-/// Standardize the error's emitted from the BSON Iterator
-/// the BSON iterator is used for validation so this should help debug the underlying incorrect binary
+/// Standardize the errors emitted from the BSON Iterator.
+/// The BSON iterator is used for validation so this should help debug the underlying incorrect binary.
 internal func BSONIterationError(
     buffer: ByteBuffer? = nil,
     key: String? = nil,

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -135,9 +135,9 @@ final class BSONCorpusTests: BSONTestCase {
                     // At the end, the new BSONDocument should be identical to the original one.
                     // If not, our BSONDocument translation layer is lossy and/or buggy.
                     // TODO(SWIFT-867): Enable these lines when you can do subscript assignment
-                    // let nativeFromDoc = docFromCB.toArray()
-                    // let docFromNative = BSONDocument(fromArray: nativeFromDoc)
-                    // expect(docFromNative.toData()).to(equal(cBData))
+                    let nativeFromDoc = docFromCB.toArray()
+                    let docFromNative = BSONDocument(fromArray: nativeFromDoc)
+                    expect(docFromNative.toData()).to(equal(cBData))
 
                     // native_to_canonical_extended_json( bson_to_native(cB) ) = cEJ
                     // expect(docFromCB.canonicalExtendedJSON).to(cleanEqual(test.canonicalExtJSON))

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -194,9 +194,8 @@ final class BSONCorpusTests: BSONTestCase {
                 }
             }
 
-            continue // TODO(SWIFT-866): Remove after validation implemented
-
             if let parseErrorTests = testFile.parseErrors {
+                continue // TODO: EXT JSON support required
                 for test in parseErrorTests where shouldRun(testFile.description, test.description) {
                     let description = "\(testFile.description)-\(test.description)"
 

--- a/Tests/BSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/BSONTests/BSONDocumentIteratorTests.swift
@@ -16,13 +16,13 @@ final class DocumentIteratorTests: BSONTestCase {
         let iter = d.makeIterator()
         let range = iter.findByteRange(for: "item1")!
 
-        let slice = d.buffer.getBytes(at: range.startIndex, length: range.length)
+        let slice = d.buffer.getBytes(at: range.startIndex, length: range.endIndex - range.startIndex)
         var bsonBytes: [UInt8] = []
         bsonBytes += [BSONType.int32.rawValue] // type
         bsonBytes += [UInt8]("item1".utf8) // key
         bsonBytes += [0x00] // null byte
         bsonBytes += [0x20, 0x00, 0x00, 0x00] // value of 32 LE
-        expect([range.startIndex, range.length]).to(equal([15, bsonBytes.count]))
+        expect([range.startIndex, range.endIndex - range.startIndex]).to(equal([15, bsonBytes.count]))
         expect(slice).to(equal(bsonBytes))
     }
 }

--- a/Tests/BSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/BSONTests/BSONDocumentIteratorTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class DocumentIteratorTests: BSONTestCase {
     func testFindByteRangeEmpty() {
         let d: BSONDocument = [:]
-        let iter = d.makeIterator()
+        var iter = d.makeIterator()
         let range = iter.findByteRange(for: "item")
         expect(range).to(beNil())
     }
 
     func testFindByteRangeItemsInt32() {
         let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
-        let iter = d.makeIterator()
+        var iter = d.makeIterator()
         let range = iter.findByteRange(for: "item1")!
 
         let slice = d.buffer.getBytes(at: range.startIndex, length: range.endIndex - range.startIndex)

--- a/Tests/BSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/BSONTests/BSONDocumentIteratorTests.swift
@@ -14,7 +14,10 @@ final class DocumentIteratorTests: BSONTestCase {
     func testFindByteRangeItemsInt32() {
         let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
         var iter = d.makeIterator()
-        let range = iter.findByteRange(for: "item1")!
+        let maybeRange = iter.findByteRange(for: "item1")
+
+        expect(maybeRange).toNot(beNil())
+        let range = maybeRange!
 
         let slice = d.buffer.getBytes(at: range.startIndex, length: range.endIndex - range.startIndex)
         var bsonBytes: [UInt8] = []

--- a/Tests/BSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/BSONTests/BSONDocumentIteratorTests.swift
@@ -1,0 +1,28 @@
+@testable import BSON
+import Foundation
+import Nimble
+import XCTest
+
+final class DocumentIteratorTests: BSONTestCase {
+    func testFindByteRangeEmpty() {
+        let d: BSONDocument = [:]
+        let iter = d.makeIterator()
+        let range = iter.findByteRange(for: "item")
+        expect(range).to(beNil())
+    }
+
+    func testFindByteRangeItemsInt32() {
+        let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
+        let iter = d.makeIterator()
+        let range = iter.findByteRange(for: "item1")!
+
+        let slice = d.buffer.getBytes(at: range.startIndex, length: range.length)
+        var bsonBytes: [UInt8] = []
+        bsonBytes += [BSONType.int32.rawValue] // type
+        bsonBytes += [UInt8]("item1".utf8) // key
+        bsonBytes += [0x00] // null byte
+        bsonBytes += [0x20, 0x00, 0x00, 0x00] // value of 32 LE
+        expect([range.startIndex, range.length]).to(equal([15, bsonBytes.count]))
+        expect(slice).to(equal(bsonBytes))
+    }
+}

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -41,4 +41,17 @@ final class DocumentTests: BSONTestCase {
         let res: BSONDocument = ["a": .int32(45), "c": .int32(90), "d": 3]
         expect(doc.buffer.byteString).to(equal(res.buffer.byteString))
     }
+
+    func testDelete() {
+        var doc: BSONDocument = ["a": .int32(32), "b": .int64(64), "c": 20]
+        doc["a"] = nil
+        doc["z"] = nil // deleting a key that doesn't exist should be a no-op
+        expect(["b", "c"]).to(equal(doc.keys))
+    }
+
+    func testDefault() {
+        let d: BSONDocument = ["hello": 12]
+        expect(d["hello", default: 0xBAD1DEA]).to(equal(12))
+        expect(d["a", default: 0xBAD1DEA]).to(equal(0xBAD1DEA))
+    }
 }

--- a/Tests/BSONTests/DocumentTests.swift
+++ b/Tests/BSONTests/DocumentTests.swift
@@ -31,4 +31,14 @@ final class DocumentTests: BSONTestCase {
     func testDynamicMemberLookup() {
         expect(DocumentTests.testDoc.int).to(equal(0xBAD1DEA))
     }
+
+    func testModifying() {
+        var doc: BSONDocument = ["a": .int32(32), "b": .int64(64), "c": 20]
+        doc["a"] = .int32(45) // change
+        doc["c"] = .int32(90) // change type
+        doc["b"] = nil // delete
+        doc["d"] = 3 // append
+        let res: BSONDocument = ["a": .int32(45), "c": .int32(90), "d": 3]
+        expect(doc.buffer.byteString).to(equal(res.buffer.byteString))
+    }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SWIFT-867
https://jira.mongodb.org/browse/SWIFT-868
https://jira.mongodb.org/browse/SWIFT-866

This will make BSONDocument's mutable, this is the work of three tickets of implementing the ability to search and splice a byte buffer to provide Create Update and Delete actions on a document. Since I rolled back the significantly more complex document iterator, the work compacted quite a bit so document validation is also in here. And validation is being tested by the corpus runner