### PR TITLE
SWIFT-892: Fix max BSON size limit to be Int32.max rather than server's default max BSON size

### DIFF
--- a/Sources/BSON/BSONDocument.swift
+++ b/Sources/BSON/BSONDocument.swift
@@ -4,7 +4,7 @@ import NIO
 /// This shared allocator instance should be used for all underlying `ByteBuffer` creation.
 internal let BSON_ALLOCATOR = ByteBufferAllocator()
 /// Maximum BSON document size in bytes
-internal let BSON_MAX_SIZE = 0x1000000
+internal let BSON_MAX_SIZE = Int32.max
 /// Minimum BSON document size in bytes
 internal let BSON_MIN_SIZE = 5
 


### PR DESCRIPTION
We use force try in the subscript setter which will check the newer, larger, size constant Int32.max.