### PR TITLE
SWIFT-960 Support outputFormatting options in ExtendedJSONEncoder

### DIFF
--- a/Sources/BSON/BSONDocument.swift
+++ b/Sources/BSON/BSONDocument.swift
@@ -142,6 +142,7 @@ public struct BSONDocument {
     /// On error, an empty string will be returned.
     public func toExtendedJSONString() -> String {
         let encoder = ExtendedJSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
         guard let encoded = try? encoder.encode(self) else {
             return ""
         }
@@ -153,6 +154,7 @@ public struct BSONDocument {
     public func toCanonicalExtendedJSONString() -> String {
         let encoder = ExtendedJSONEncoder()
         encoder.mode = .canonical
+        encoder.outputFormatting = [.prettyPrinted]
         guard let encoded = try? encoder.encode(self) else {
             return ""
         }
@@ -461,4 +463,8 @@ extension BSONDocument: BSONValue {
         var doc = ByteBuffer(self.storage.buffer.readableBytesView)
         buffer.writeBuffer(&doc)
     }
+}
+
+extension BSONDocument: CustomStringConvertible {
+    public var description: String { self.toExtendedJSONString() }
 }

--- a/Sources/BSON/ExtendedJSONEncoder.swift
+++ b/Sources/BSON/ExtendedJSONEncoder.swift
@@ -14,11 +14,35 @@ public class ExtendedJSONEncoder {
         case relaxed
     }
 
+    /// The output formatting options that determine the readability, size, and element order of an encoded JSON object.
+    public struct OutputFormatting: OptionSet {
+        internal let value: JSONEncoder.OutputFormatting
+
+        public var rawValue: UInt { self.value.rawValue }
+
+        public init(rawValue: UInt) {
+            self.value = JSONEncoder.OutputFormatting(rawValue: rawValue)
+        }
+
+        internal init(_ value: JSONEncoder.OutputFormatting) {
+            self.value = value
+        }
+
+        /// Produce human-readable JSON with indented output.
+        public static let prettyPrinted = OutputFormatting(.prettyPrinted)
+
+        /// Produce JSON with dictionary keys sorted in lexicographic order.
+        public static let sortedKeys = OutputFormatting(.sortedKeys)
+    }
+
     /// Determines whether to encode to canonical or relaxed extended JSON. Default is relaxed.
     public var mode: Mode = .relaxed
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey: Any] = [:]
+
+    /// A value that determines the readability, size, and element order of the encoded JSON object.
+    public var outputFormatting: ExtendedJSONEncoder.OutputFormatting = []
 
     /// Initialize an `ExtendedJSONEncoder`.
     public init() {}
@@ -50,6 +74,8 @@ public class ExtendedJSONEncoder {
             json = bson.bsonValue.toRelaxedExtendedJSON()
         }
 
-        return try JSONEncoder().encode(json)
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = self.outputFormatting.value
+        return try jsonEncoder.encode(json)
     }
 }

--- a/Tests/BSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/BSONTests/ExtendedJSONConversionTests.swift
@@ -107,11 +107,11 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         let encoder = ExtendedJSONEncoder()
         let input: BSONDocument = ["topLevel": ["hello": "world"]]
 
-        let defaultFormat = String(data: try encoder.encode(input), encoding: .utf8) ?? ""
+        let defaultFormat = String(data: try encoder.encode(input), encoding: .utf8)
         expect(defaultFormat).to(equal("{\"topLevel\":{\"hello\":\"world\"}}"))
 
         encoder.outputFormatting = [.prettyPrinted]
-        let prettyPrint = String(data: try encoder.encode(input), encoding: .utf8) ?? ""
+        let prettyPrint = String(data: try encoder.encode(input), encoding: .utf8)
         let prettyOutput = """
         {
           "topLevel" : {
@@ -124,11 +124,11 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         let multiKeyInput: BSONDocument = ["x": 1, "a": 2]
 
         encoder.outputFormatting = [.sortedKeys]
-        let sorted = String(data: try encoder.encode(multiKeyInput), encoding: .utf8) ?? ""
+        let sorted = String(data: try encoder.encode(multiKeyInput), encoding: .utf8)
         expect(sorted).to(equal("{\"a\":2,\"x\":1}"))
 
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        let both = String(data: try encoder.encode(multiKeyInput), encoding: .utf8) ?? ""
+        let both = String(data: try encoder.encode(multiKeyInput), encoding: .utf8)
         let sortedPrettyOutput = """
         {
           \"a\" : 2,

--- a/Tests/BSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/BSONTests/ExtendedJSONConversionTests.swift
@@ -338,8 +338,18 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         expect(try BSONDocument(fromJSON: "{\"key\": {\"$numberInt\": \"5\"}}".data(using: .utf8)!))
             .to(equal(["key": .int32(5)]))
 
-        let canonicalExtJSON = "{\"key\":{\"$numberInt\":\"5\"}}"
-        let relaxedExtJSON = "{\"key\":5}"
+        let canonicalExtJSON = """
+        {
+          "key" : {
+            "$numberInt" : "5"
+          }
+        }
+        """
+        let relaxedExtJSON = """
+        {
+          "key" : 5
+        }
+        """
         let canonicalDoc = try BSONDocument(fromJSON: canonicalExtJSON)
         let relaxedDoc = try BSONDocument(fromJSON: relaxedExtJSON)
         expect(canonicalDoc).to(equal(["key": .int32(5)]))

--- a/Tests/BSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/BSONTests/ExtendedJSONConversionTests.swift
@@ -103,6 +103,41 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         expect(String(data: fooEncoded, encoding: .utf8)).to(contain("false"))
     }
 
+    func testOutputFormatting() throws {
+        let encoder = ExtendedJSONEncoder()
+        let input: BSONDocument = ["topLevel": ["hello": "world"]]
+
+        let defaultFormat = String(data: try encoder.encode(input), encoding: .utf8) ?? ""
+        expect(defaultFormat).to(equal("{\"topLevel\":{\"hello\":\"world\"}}"))
+
+        encoder.outputFormatting = [.prettyPrinted]
+        let prettyPrint = String(data: try encoder.encode(input), encoding: .utf8) ?? ""
+        let prettyOutput = """
+        {
+          "topLevel" : {
+            "hello" : "world"
+          }
+        }
+        """
+        expect(prettyPrint).to(equal(prettyOutput))
+
+        let multiKeyInput: BSONDocument = ["x": 1, "a": 2]
+
+        encoder.outputFormatting = [.sortedKeys]
+        let sorted = String(data: try encoder.encode(multiKeyInput), encoding: .utf8) ?? ""
+        expect(sorted).to(equal("{\"a\":2,\"x\":1}"))
+
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        let both = String(data: try encoder.encode(multiKeyInput), encoding: .utf8) ?? ""
+        let sortedPrettyOutput = """
+        {
+          \"a\" : 2,
+          \"x\" : 1
+        }
+        """
+        expect(both).to(equal(sortedPrettyOutput))
+    }
+
     func testAnyExtJSON() throws {
         // Success cases
         expect(try BSON(fromExtJSON: "hello", keyPath: [])).to(equal(BSON.string("hello")))


### PR DESCRIPTION
SWIFT-960

This PR adds support for output formatting options on `ExtendedJSONEncoder` similar to [the ones offered on `JSONEncoder`](https://developer.apple.com/documentation/foundation/jsonencoder/outputformatting).