### PR TITLE
Bump Swiftlint version and fix violations, add missing docs

### DIFF
--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -39,7 +39,7 @@ swiftenv local $SWIFT_VERSION
 
 if [ $1 == "swiftlint" ]
 then
-    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.39.2"
+    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.40.0"
 elif [ $1 == "swiftformat" ]
 then
     build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.44.13"

--- a/Sources/BSON/BSONDecimal128.swift
+++ b/Sources/BSON/BSONDecimal128.swift
@@ -118,6 +118,7 @@ internal struct UInt128: Equatable, Hashable {
     }
 }
 
+/// A struct to represent the BSON Decimal128 type.
 public struct BSONDecimal128: Equatable, Hashable, CustomStringConvertible {
     // swiftlint:disable line_length
     private static let digitsRegex = #"(?:\d+)"#
@@ -182,6 +183,8 @@ public struct BSONDecimal128: Equatable, Hashable, CustomStringConvertible {
         self.value = value
     }
 
+    /// Initializes a new `BSONDecimal128` from the input string.
+    /// - Throws: `BSONError.InvalidArgumentError` if the input is not a valid Decimal128 string.
     public init(_ data: String) throws {
         // swiftlint:disable:previous cyclomatic_complexity
         let regex = try NSRegularExpression(

--- a/Sources/BSON/BSONDocumentIterator.swift
+++ b/Sources/BSON/BSONDocumentIterator.swift
@@ -1,6 +1,8 @@
 import Foundation
 import NIO
 
+/// Iterator over a `BSONDocument`. This type is not meant to be used directly; please use `Sequence` protocol methods
+/// instead.
 public struct BSONDocumentIterator: IteratorProtocol {
     /// The buffer we are iterating over.
     private var buffer: ByteBuffer

--- a/Sources/BSON/BSONTimestamp.swift
+++ b/Sources/BSON/BSONTimestamp.swift
@@ -1,5 +1,8 @@
 import NIO
 
+/// A struct to represent the BSON Timestamp type. This type is for internal MongoDB use. For most cases, in
+/// application development, you should use the BSON date type (represented in this library by `Date`.)
+/// - SeeAlso: https://docs.mongodb.com/manual/reference/bson-types/#timestamps
 public struct BSONTimestamp: BSONValue, Equatable, Hashable {
     internal static var bsonType: BSONType { .timestamp }
     internal var bson: BSON { .timestamp(self) }

--- a/Sources/BSON/Integers+BSONValue.swift
+++ b/Sources/BSON/Integers+BSONValue.swift
@@ -45,12 +45,12 @@ extension Int32: BSONValue {
     }
 
     /// Converts this `Int32` to a corresponding `JSON` in relaxed extendedJSON format.
-    func toRelaxedExtendedJSON() -> JSON {
+    internal func toRelaxedExtendedJSON() -> JSON {
         .number(Double(self))
     }
 
     /// Converts this `Int32` to a corresponding `JSON` in canonical extendedJSON format.
-    func toCanonicalExtendedJSON() -> JSON {
+    internal func toCanonicalExtendedJSON() -> JSON {
         ["$numberInt": .string(String(describing: self))]
     }
 
@@ -115,12 +115,12 @@ extension Int64: BSONValue {
     }
 
     /// Converts this `Int64` to a corresponding `JSON` in relaxed extendedJSON format.
-    func toRelaxedExtendedJSON() -> JSON {
+    internal func toRelaxedExtendedJSON() -> JSON {
         .number(Double(self))
     }
 
     /// Converts this `Int64` to a corresponding `JSON` in canonical extendedJSON format.
-    func toCanonicalExtendedJSON() -> JSON {
+    internal func toCanonicalExtendedJSON() -> JSON {
         ["$numberLong": .string(String(describing: self))]
     }
 

--- a/Sources/BSON/String+BSONValue.swift
+++ b/Sources/BSON/String+BSONValue.swift
@@ -22,12 +22,12 @@ extension String: BSONValue {
     }
 
     /// Converts this `String` to a corresponding `JSON` in relaxed extendedJSON format.
-    func toRelaxedExtendedJSON() -> JSON {
+    internal func toRelaxedExtendedJSON() -> JSON {
         self.toCanonicalExtendedJSON()
     }
 
     /// Converts this `String` to a corresponding `JSON` in canonical extendedJSON format.
-    func toCanonicalExtendedJSON() -> JSON {
+    internal func toCanonicalExtendedJSON() -> JSON {
         .string(self)
     }
 


### PR DESCRIPTION
I got my new laptop and installed a newer SwiftLint version and found some new violations. It turns out there was a bug in SwiftLint 0.39.2 where the explicit ACL rule was not enforced in extensions.

Testing out docs generation, I also found some places where the missing_docs rule seems to not be enforced so I have added docs where needed.

I will bump the SwiftLint version on the driver as well for consistency.