### PR TITLE
Add basic landing page README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# swift-bson Documentation
+
+This is the documentation for the official MongoDB Swift BSON library, [swift-bson](https://github.com/mongodb/swift-bson).
+
+You can view the README for this project, including installation instructions, [here](https://github.com/mongodb/swift-bson/blob/master/README.md).
+
+The documentation for the official MongoDB Swift driver, which depends on this BSON library, can be found [here](https://mongodb.github.io/mongo-swift-driver/MongoSwift/index.html).


### PR DESCRIPTION
This is a very basic landing page for the docs, equivalent to the current landing page for the driver docs. (I'll update that to link to the BSON docs later on.)

I've set up this repo so that it deploys to GitHub pages from the gh-pages branch.

My next step will be to write a documentation generation script which:
- generates the docs based on master
- checks out the gh-pages branch
- commits the doc changes and pushes them to this branch