### PR TITLE
SWIFT-937 Add a release script

### DIFF
--- a/etc/release.sh
+++ b/etc/release.sh
@@ -6,14 +6,18 @@
 set -e
 
 # ensure we are on master before releasing
-git checkout master
+#git checkout master
+
+version=${1}
+# Ensure version is non-empty
+[ ! -z "${version}" ] || { echo "ERROR: Missing version string"; exit 1; }
 
 # regenerate documentation with new version string
-./etc/generate-docs.sh ${1}
+./etc/generate-docs.sh ${version}
 
 # tag release and push tag
-git tag "v${1}"
+git tag "v${version}"
 git push --tags
 
 # go to GitHub to publish release notes
-open "https://github.com/mongodb/swift-bson/releases/tag/v${1}"
+open "https://github.com/mongodb/swift-bson/releases/tag/v${version}"

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# usage: ./etc/release.sh [new version string]
+
+# exit if any command fails
+set -e
+
+# ensure we are on master before releasing
+git checkout master
+
+# regenerate documentation with new version string
+./etc/generate-docs.sh ${1}
+
+# tag release and push tag
+git tag "v${1}"
+git push --tags
+
+# go to GitHub to publish release notes
+open "https://github.com/mongodb/swift-bson/releases/tag/v${1}"

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -6,7 +6,7 @@
 set -e
 
 # ensure we are on master before releasing
-#git checkout master
+git checkout master
 
 version=${1}
 # Ensure version is non-empty


### PR DESCRIPTION
Adds a release script. I haven't run it to completion for obvious reasons but it borrows strongly from the driver's script so I think it will work fine.

In testing this I did accidentally prematurely publish the 3.0 docs (forgot to comment out stuff in that script to commit and push...) but I think that's fine, we aren't linking to it anywhere yet.