### PR TITLE
SWIFT-968 Enable Decimal128 parseError assertion

### DIFF
--- a/Sources/BSON/BSONDocument.swift
+++ b/Sources/BSON/BSONDocument.swift
@@ -298,7 +298,7 @@ public struct BSONDocument {
         self.storage = newStorage
         self.byteLength = newSize
         guard self.byteLength == self.storage.buffer.readableBytes else {
-            fatalError("BSONDocument's encoded byte length is \(self.byteLength) however the" +
+            fatalError("BSONDocument's encoded byte length is \(self.byteLength), however the " +
                 "buffer has \(self.storage.buffer.readableBytes) readable bytes")
         }
     }

--- a/Tests/BSONTests/BSONCorpusTests.swift
+++ b/Tests/BSONTests/BSONCorpusTests.swift
@@ -251,10 +251,11 @@ final class BSONCorpusTests: BSONTestCase {
                         expect(try decoder.decode(BSONDocument.self, from: testData))
                             .to(throwError(errorType: DecodingError.self), description: description)
                     case .decimal128:
-                        continue // TODO: SWIFT-968
+                        expect(try BSONDecimal128(test.string))
+                            .to(throwError(), description: description)
                     default:
                         throw TestError(
-                            message: "\(description): parse error tests not implemented"
+                            message: "\(description): parse error tests not implemented "
                                 + "for bson type \(testFile.bsonType)"
                         )
                     }


### PR DESCRIPTION
It turns out all of the issues we had with these before were fixed by d070d9ca40f0d1a1b479a366f81a087e0733d02a so this just enables the assertions.
I also fixed a couple of error messages missing spaces that I happened to notice.