### PR TITLE
SWIFT-935 Fix API breakages from old BSON library

### DIFF
--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -10,7 +10,7 @@ public struct BSONBinary: Equatable, Hashable {
     public let subtype: Subtype
 
     /// Subtypes for BSON Binary values.
-    public struct Subtype: Equatable, Hashable, RawRepresentable {
+    public struct Subtype: Equatable, Hashable, RawRepresentable, Codable {
         // swiftlint:disable force_unwrapping
         /// Generic binary subtype
         public static let generic = Subtype(rawValue: 0x00)!

--- a/Sources/SwiftBSON/BSONDocument+Collection.swift
+++ b/Sources/SwiftBSON/BSONDocument+Collection.swift
@@ -38,7 +38,7 @@ extension BSONDocument: Collection {
         // criticism also applies to key-based subscripting via `String`.
         // See SWIFT-250.
         self.failIndexCheck(position)
-        var iter = BSONDocumentIterator(over: self)
+        let iter = BSONDocumentIterator(over: self)
 
         for pos in 0..<position {
             guard (try? iter.nextThrowing()) != nil else {

--- a/Sources/SwiftBSON/BSONDocument.swift
+++ b/Sources/SwiftBSON/BSONDocument.swift
@@ -259,7 +259,7 @@ public struct BSONDocument {
             return
         }
 
-        var iter = BSONDocumentIterator(over: self.storage.buffer)
+        let iter = BSONDocumentIterator(over: self.storage.buffer)
 
         guard let range = iter.findByteRange(for: key) else {
             throw BSONError.InternalError(message: "Cannot find \(key) to delete")
@@ -342,7 +342,7 @@ public struct BSONDocument {
                 )
             }
 
-            var iter = BSONDocumentIterator(over: self.buffer)
+            let iter = BSONDocumentIterator(over: self.buffer)
             // Implicitly validate with iterator
             do {
                 while let (_, value) = try iter.nextThrowing() {

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -3,7 +3,7 @@ import NIO
 
 /// Iterator over a `BSONDocument`. This type is not meant to be used directly; please use `Sequence` protocol methods
 /// instead.
-public struct BSONDocumentIterator: IteratorProtocol {
+public class BSONDocumentIterator: IteratorProtocol {
     /// The buffer we are iterating over.
     private var buffer: ByteBuffer
     private var exhausted: Bool
@@ -15,12 +15,12 @@ public struct BSONDocumentIterator: IteratorProtocol {
         self.buffer.moveReaderIndex(to: 4)
     }
 
-    internal init(over doc: BSONDocument) {
-        self = BSONDocumentIterator(over: doc.buffer)
+    internal convenience init(over doc: BSONDocument) {
+        self.init(over: doc.buffer)
     }
 
     /// Advances to the next element and returns it, or nil if no next element exists.
-    public mutating func next() -> BSONDocument.KeyValuePair? {
+    public func next() -> BSONDocument.KeyValuePair? {
         // The only time this would crash is when the document is incorrectly formatted
         do {
             return try self.nextThrowing()
@@ -34,7 +34,7 @@ public struct BSONDocumentIterator: IteratorProtocol {
      * - Throws:
      *   - `InternalError` if the underlying buffer contains invalid BSON
      */
-    internal mutating func nextThrowing() throws -> BSONDocument.KeyValuePair? {
+    internal func nextThrowing() throws -> BSONDocument.KeyValuePair? {
         guard self.buffer.readableBytes != 0 else {
             // Iteration has been exhausted
             guard self.exhausted else {
@@ -88,7 +88,7 @@ public struct BSONDocumentIterator: IteratorProtocol {
 
     /// Finds the key in the underlying buffer, and returns the [startIndex, endIndex) containing the corresponding
     /// element.
-    internal mutating func findByteRange(for searchKey: String) -> Range<Int>? {
+    internal func findByteRange(for searchKey: String) -> Range<Int>? {
         while true {
             let startIndex = self.buffer.readerIndex
             guard let (key, _) = self.next() else {
@@ -116,7 +116,7 @@ public struct BSONDocumentIterator: IteratorProtocol {
             fatalError("endIndex must be >= startIndex")
         }
 
-        var iter = BSONDocumentIterator(over: doc)
+        let iter = BSONDocumentIterator(over: doc)
 
         var excludedKeys: [String] = []
 

--- a/Sources/SwiftBSON/BSONTimestamp.swift
+++ b/Sources/SwiftBSON/BSONTimestamp.swift
@@ -18,6 +18,12 @@ public struct BSONTimestamp: BSONValue, Equatable, Hashable {
         self.increment = inc
     }
 
+    /// Initializes a new  `BSONTimestamp` with the provided `timestamp` and `increment` values. Assumes
+    /// the values can successfully be converted to `UInt32`s without loss of precision.
+    public init(timestamp: Int, inc: Int) {
+        self.init(timestamp: UInt32(timestamp), inc: UInt32(inc))
+    }
+
     /*
      * Initializes a `BSONTimestamp` from ExtendedJSON.
      *

--- a/Tests/SwiftBSONTests/BSONDocument+SequenceTests.swift
+++ b/Tests/SwiftBSONTests/BSONDocument+SequenceTests.swift
@@ -21,7 +21,7 @@ final class Document_SequenceTests: BSONTestCase {
         ]
 
         // create and use iter manually
-        var iter = doc.makeIterator()
+        let iter = doc.makeIterator()
 
         let stringTup = iter.next()!
         expect(stringTup.key).to(equal("string"))

--- a/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
@@ -6,14 +6,14 @@ import XCTest
 final class DocumentIteratorTests: BSONTestCase {
     func testFindByteRangeEmpty() {
         let d: BSONDocument = [:]
-        var iter = d.makeIterator()
+        let iter = d.makeIterator()
         let range = iter.findByteRange(for: "item")
         expect(range).to(beNil())
     }
 
     func testFindByteRangeItemsInt32() {
         let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
-        var iter = d.makeIterator()
+        let iter = d.makeIterator()
         let maybeRange = iter.findByteRange(for: "item1")
 
         expect(maybeRange).toNot(beNil())


### PR DESCRIPTION
SWIFT-935

This PR fixes a few API breakages detected via `swift api-digestor` (via [this script](https://github.com/apple/swift-nio/blob/master/scripts/check_no_api_breakages.sh) from SwiftNIO).

The changes are as following:
- switch `BSONDocumentIterator` back to a `class` (was a `struct`)
- add missing initializer to `BSONTimestamp` (SWIFT-999)
- add missing `Codable` conformance to `BSONBinary.Subtype`

Since `swift api-digester` doesn't recognize `@_exported` types, I manually copied over the entirety of `swift-bson` into the driver and ran it instead. The branch for that is [here](https://github.com/patrickfreed/mongo-swift-driver/tree/drop-in-swift-bson) if you want to try it out yourself. It's based off of the `SWIFT-936/new-bson-library` branch on this repository.

The script is still currently complaining about the omission of some methods, but they all appear to be `Codable` initializers we now get by default from `BSONValue` or `Equatable` methods that are synthesized by the compiler.

Here is the output I'm seeing:
```
Checking MongoSwift.json... ERROR
==============================
ERROR: public API change in MongoSwift.json
==============================
could not open '//System/Library/CoreServices/SystemVersion.plist': No such file or directory

/* Generic Signature Changes */

/* RawRepresentable Changes */

/* Removed Decls */
Constructor BSONBinary.init(from:) has been removed
Constructor BSONCode.init(from:) has been removed
Constructor BSONCodeWithScope.init(from:) has been removed
Constructor BSONDBPointer.init(from:) has been removed
Constructor BSONDecimal128.init(from:) has been removed
Constructor BSONDocument.init(from:) has been removed
Constructor BSONRegularExpression.init(from:) has been removed
Constructor BSONSymbol.init(from:) has been removed
Constructor BSONTimestamp.init(from:) has been removed
Func BSONBinary.encode(to:) has been removed
Func BSONCode.encode(to:) has been removed
Func BSONCodeWithScope.encode(to:) has been removed
Func BSONDBPointer.encode(to:) has been removed
Func BSONDecimal128.==(_:_:) has been removed
Func BSONDecimal128.encode(to:) has been removed
Func BSONDocument.encode(to:) has been removed
Func BSONObjectID.==(_:_:) has been removed
Func BSONRegularExpression.encode(to:) has been removed
Func BSONSymbol.encode(to:) has been removed
Func BSONTimestamp.encode(to:) has been removed

/* Moved Decls */

/* Renamed Decls */

/* Type Changes */

/* Decl Attribute changes */

/* Fixed-layout Type Changes */

/* Protocol Conformance Change */

/* Protocol Requirement Change */

/* Class Inheritance Change */
Checking MongoSwiftSync.json... ERROR
==============================

```