### PR TITLE
SWIFT-1016 Add a public withID() method

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
   - todo
   - type_body_length
   - type_name
+  - cyclomatic_complexity
 
 opt_in_rules:
   - array_init

--- a/Tests/SwiftBSONTests/DocumentTests.swift
+++ b/Tests/SwiftBSONTests/DocumentTests.swift
@@ -758,4 +758,28 @@ final class DocumentTests: BSONTestCase {
             expect(try BSONDocument(fromBSON: data)).to(throwError(errorType: BSONError.InvalidArgumentError.self))
         }
     }
+
+    func testWithID() throws {
+        let doc1: BSONDocument = ["a": .int32(1)]
+
+        let withID1 = try doc1.withID()
+        expect(withID1.keys).to(equal(["_id", "a"]))
+        expect(withID1["_id"]?.objectIDValue).toNot(beNil())
+
+        let data = withID1.toData()
+        // 4 for length, 17 for "_id": oid, 7 for "a": 1, 1 for null terminator
+        expect(data).to(haveCount(29))
+
+        // verify a document with an _id is unchanged by calling this method
+        let doc2: BSONDocument = ["x": 1, "_id": .objectID()]
+        let withID2 = try doc2.withID()
+        expect(withID2).to(equal(doc2))
+    }
+
+    func testDuplicateKeyInBSON() throws {
+        // contains multiple values for key "a"
+        let hex = "1b0000001261000100000000000000126100020000000000000000"
+        let data = Data(hexString: hex)!
+        expect(try BSONDocument(fromBSON: data)).to(throwError(errorType: BSONError.InvalidArgumentError.self))
+    }
 }

--- a/Tests/SwiftBSONTests/DocumentTests.swift
+++ b/Tests/SwiftBSONTests/DocumentTests.swift
@@ -770,6 +770,16 @@ final class DocumentTests: BSONTestCase {
         // 4 for length, 17 for "_id": oid, 7 for "a": 1, 1 for null terminator
         expect(data).to(haveCount(29))
 
+        // build what we expect the data to look like
+        let length = "1d000000" // little-endian Int32 rep of 29
+        // byte prefix for ObjectID + "_id" as cstring + oid bytes
+        let oid = "07" + "5f696400" + withID1["_id"]!.objectIDValue!.hex
+        // byte prefix for Int32 + "a" as cstring + little-endian Int32 rep of 1
+        let a = "10" + "6100" + "01000000"
+
+        let expectedHex = length + oid + a + "00" // null terminator
+        expect(data.hexDescription).to(equal(expectedHex))
+
         // verify a document with an _id is unchanged by calling this method
         let doc2: BSONDocument = ["x": 1, "_id": .objectID()]
         let withID2 = try doc2.withID()


### PR DESCRIPTION
This adds a `withID()` method to `BSONDocument` and does a bit of internal refactoring.

Runtime comparisons for relevant benchmarks:
| Benchmark                        | Old   | With SWIFT-1015 | With this fix |
|----------------------------------|-------|-----------------|---------------|
| Small doc bulk insert 10k copies | .096  | 0.424           | 0.116         |
| Large doc bulk insert 10 copies  | 0.332 | 2.79            | 0.352         |
| small doc insertOne 10k times    | 3.258 | 4.481           | 4.021         |
| large doc insertOne 10 times     | 0.327 | 2.812           | 0.326         |