### PR TITLE
SWIFT-1044 Improve BSON to JSON performance

### DIFF
--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -265,16 +265,16 @@ extension BSONBinary: BSONValue {
             guard oldSize == (byteLength - 4) else {
                 throw BSONError.InternalError(message: "Invalid size for BSONBinary subtype: \(subtype)")
             }
-            guard let bytes = buffer.readBytes(length: Int(oldSize)) else {
+            guard let bytes = buffer.readSlice(length: Int(oldSize)) else {
                 throw BSONError.InternalError(message: "Cannot read \(oldSize) from buffer for BSONBinary")
             }
-            return .binary(try BSONBinary(bytes: bytes, subtype: subtype))
+            return .binary(try BSONBinary(buffer: bytes, subtype: subtype))
         }
 
-        guard let bytes = buffer.readBytes(length: Int(byteLength)) else {
+        guard let bytes = buffer.readSlice(length: Int(byteLength)) else {
             throw BSONError.InternalError(message: "Cannot read \(byteLength) from buffer for BSONBinary")
         }
-        return .binary(try BSONBinary(bytes: bytes, subtype: subtype))
+        return .binary(try BSONBinary(buffer: bytes, subtype: subtype))
     }
 
     internal func write(to buffer: inout ByteBuffer) {

--- a/Sources/SwiftBSON/BSONDocument+Sequence.swift
+++ b/Sources/SwiftBSON/BSONDocument+Sequence.swift
@@ -22,6 +22,16 @@ extension BSONDocument: Sequence {
         BSONDocumentIterator(over: self.buffer)
     }
 
+    // We need to re-implement this using the default Sequence implementation since the default one from
+    // `Collection` (which `BSONDocument` also conforms to) relies on numeric indexes for iteration and is therefore
+    // very slow.
+    @inlinable
+    public func map<T>(
+        _ transform: (Element) throws -> T
+    ) rethrows -> [T] {
+        try AnySequence(self).map(transform)
+    }
+
     /**
      * Returns a new document containing the keys of this document with the values transformed by the given closure.
      *

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -98,10 +98,7 @@ public class BSONDocumentIterator: IteratorProtocol {
     /// Finds an element with the specified key in the document. Returns nil if the key is not found.
     internal static func find(key: String, in document: BSONDocument) throws -> BSONDocument.KeyValuePair? {
         let iter = document.makeIterator()
-        while true {
-            guard let type = try iter.readNextType() else {
-                return nil
-            }
+        while let type = try iter.readNextType() {
             let foundKey = try iter.buffer.readCString()
             if foundKey == key {
                 // the map contains a value for every valid BSON type.
@@ -112,6 +109,7 @@ public class BSONDocumentIterator: IteratorProtocol {
 
             try iter.skipNextValue(type: type)
         }
+        return nil
     }
 
     /// Given the type of the encoded value starting at self.buffer.readerIndex, advances the reader index to the index

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -40,9 +40,9 @@ public class BSONDocumentIterator: IteratorProtocol {
             return nil
         }
         let key = try self.buffer.readCString()
-        // the map contains a value for every valid BSON type.
-        // swiftlint:disable:next force_unwrapping
-        let bson = try BSON.allBSONTypes[type]!.read(from: &self.buffer)
+        guard let bson = try BSON.allBSONTypes[type]?.read(from: &self.buffer) else {
+            throw BSONIterationError(message: "Encountered invalid BSON type: \(type)")
+        }
         return (key: key, value: bson)
     }
 

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -117,7 +117,7 @@ public class BSONDocumentIterator: IteratorProtocol {
     internal func skipNextValue(type: BSONType) throws {
         switch type {
         case .invalid:
-            fatalError("Unexpectedly encountered invalid BSON type")
+            throw BSONIterationError(message: "encountered invalid BSON type")
 
         case .undefined, .null, .minKey, .maxKey:
             // no data stored, nothing to skip.

--- a/Sources/SwiftBSON/ByteBuffer+BSON.swift
+++ b/Sources/SwiftBSON/ByteBuffer+BSON.swift
@@ -10,26 +10,20 @@ extension ByteBuffer {
 
     /// Attempts to read null terminated UTF-8 string from ByteBuffer starting at the readerIndex
     internal mutating func readCString() throws -> String {
-        let string = try self.getCString(at: self.readerIndex)
-        self.moveReaderIndex(forwardBy: string.utf8.count + 1)
-        return string
-    }
-
-    /// Attempts to read null terminated UTF-8 string from ByteBuffer starting at the readerIndex
-    internal func getCString(at offset: Int) throws -> String {
         var string: [UInt8] = []
-        for i in 0..<Int(BSON_MAX_SIZE) {
-            if let b = self.getBytes(at: offset + i, length: 1) {
-                if b[0] == 0 {
-                    guard let s = String(bytes: string, encoding: .utf8) else {
-                        throw BSONError.InternalError(message: "Unable to decode utf8 string from \(string)")
-                    }
-                    return s
-                }
-                string += b
-            } else {
+        for _ in 0..<Int(BSON_MAX_SIZE) {
+            guard let b = self.readInteger(endianness: .little, as: UInt8.self) else {
                 throw BSONError.InternalError(message: "Failed to read CString, unable to read byte from \(self)")
             }
+
+            guard b != 0 else {
+                guard let s = String(bytes: string, encoding: .utf8) else {
+                    throw BSONError.InternalError(message: "Unable to decode utf8 string from \(string)")
+                }
+                return s
+            }
+
+            string.append(b)
         }
         throw BSONError.InternalError(message: "Failed to read CString, possibly missing null terminator?")
     }

--- a/Sources/SwiftBSON/ExtendedJSONEncoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONEncoder.swift
@@ -15,35 +15,11 @@ public class ExtendedJSONEncoder {
         case relaxed
     }
 
-    /// The output formatting options that determine the readability, size, and element order of an encoded JSON object.
-    public struct OutputFormatting: OptionSet {
-        internal let value: JSONEncoder.OutputFormatting
-
-        public var rawValue: UInt { self.value.rawValue }
-
-        public init(rawValue: UInt) {
-            self.value = JSONEncoder.OutputFormatting(rawValue: rawValue)
-        }
-
-        internal init(_ value: JSONEncoder.OutputFormatting) {
-            self.value = value
-        }
-
-        /// Produce human-readable JSON with indented output.
-        public static let prettyPrinted = OutputFormatting(.prettyPrinted)
-
-        /// Produce JSON with dictionary keys sorted in lexicographic order.
-        public static let sortedKeys = OutputFormatting(.sortedKeys)
-    }
-
     /// Determines whether to encode to canonical or relaxed extended JSON. Default is relaxed.
     public var mode: Mode = .relaxed
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey: Any] = [:]
-
-    /// A value that determines the readability, size, and element order of the encoded JSON object.
-    public var outputFormatting: ExtendedJSONEncoder.OutputFormatting = []
 
     /// Initialize an `ExtendedJSONEncoder`.
     public init() {}
@@ -75,8 +51,8 @@ public class ExtendedJSONEncoder {
             json = bson.bsonValue.toRelaxedExtendedJSON()
         }
 
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.outputFormatting = self.outputFormatting.value
-        return try jsonEncoder.encode(json)
+        var bytes: [UInt8] = []
+        json.value.appendBytes(to: &bytes)
+        return Data(bytes)
     }
 }

--- a/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
@@ -4,17 +4,15 @@ import Nimble
 import XCTest
 
 final class DocumentIteratorTests: BSONTestCase {
-    func testFindByteRangeEmpty() {
+    func testFindByteRangeEmpty() throws {
         let d: BSONDocument = [:]
-        let iter = d.makeIterator()
-        let range = iter.findByteRange(for: "item")
+        let range = try BSONDocumentIterator.findByteRange(for: "item", in: d)
         expect(range).to(beNil())
     }
 
-    func testFindByteRangeItemsInt32() {
+    func testFindByteRangeItemsInt32() throws {
         let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
-        let iter = d.makeIterator()
-        let maybeRange = iter.findByteRange(for: "item1")
+        let maybeRange = try BSONDocumentIterator.findByteRange(for: "item1", in: d)
 
         expect(maybeRange).toNot(beNil())
         let range = maybeRange!

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -123,41 +123,6 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         expect(String(data: fooEncoded, encoding: .utf8)).to(contain("false"))
     }
 
-    func testOutputFormatting() throws {
-        let encoder = ExtendedJSONEncoder()
-        let input: BSONDocument = ["topLevel": ["hello": "world"]]
-
-        let defaultFormat = String(data: try encoder.encode(input), encoding: .utf8)
-        expect(defaultFormat).to(equal("{\"topLevel\":{\"hello\":\"world\"}}"))
-
-        encoder.outputFormatting = [.prettyPrinted]
-        let prettyPrint = String(data: try encoder.encode(input), encoding: .utf8)
-        let prettyOutput = """
-        {
-          "topLevel" : {
-            "hello" : "world"
-          }
-        }
-        """
-        expect(prettyPrint).to(equal(prettyOutput))
-
-        let multiKeyInput: BSONDocument = ["x": 1, "a": 2]
-
-        encoder.outputFormatting = [.sortedKeys]
-        let sorted = String(data: try encoder.encode(multiKeyInput), encoding: .utf8)
-        expect(sorted).to(equal("{\"a\":2,\"x\":1}"))
-
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        let both = String(data: try encoder.encode(multiKeyInput), encoding: .utf8)
-        let sortedPrettyOutput = """
-        {
-          \"a\" : 2,
-          \"x\" : 1
-        }
-        """
-        expect(both).to(equal(sortedPrettyOutput))
-    }
-
     func testAnyExtJSON() throws {
         // Success cases
         expect(try BSON(fromExtJSON: "hello", keyPath: [])).to(equal(BSON.string("hello")))
@@ -362,17 +327,9 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             .to(equal(["key": .int32(5)]))
 
         let canonicalExtJSON = """
-        {
-          "key" : {
-            "$numberInt" : "5"
-          }
-        }
+        {"key":{"$numberInt":"5"}}
         """
-        let relaxedExtJSON = """
-        {
-          "key" : 5
-        }
-        """
+        let relaxedExtJSON = "{\"key\":5}"
         let canonicalDoc = try BSONDocument(fromJSON: canonicalExtJSON)
         let relaxedDoc = try BSONDocument(fromJSON: relaxedExtJSON)
         expect(canonicalDoc).to(equal(["key": .int32(5)]))


### PR DESCRIPTION
SWIFT-1044

This PR implements a number of improvements to extended JSON generation as laid out in the design doc. Most of the code changes ended up being the original iterator improvements you wrote a while back.

benchmark results (in seconds median execution time):
|             | flat_bson | deep_bson | full_bson |
|-------------|-----------|-----------|-----------|
| libbson     |       2.0 |       0.8 |       1.2 |
| unoptimized |      31.5 |     207.6 |      46.6 |
| target      |       8.0 |       3.2 |       4.6 |
| optimized   |       3.2 |       2.5 |       4.2 |
