### PR TITLE
SWIFT-1072 Improve insertion performance

### DIFF
--- a/Sources/SwiftBSON/BSONDocument.swift
+++ b/Sources/SwiftBSON/BSONDocument.swift
@@ -269,7 +269,7 @@ public struct BSONDocument {
      * Sets a BSON element with the corresponding key
      * if element.value is nil the element is deleted from the BSON
      */
-    internal mutating func set(key: String, to value: BSON?) {
+    private mutating func set(key: String, to value: BSON?) {
         guard let range = BSONDocumentIterator.findByteRange(for: key, in: self) else {
             guard let value = value else {
                 // no-op: key does not exist and the value is nil

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -112,14 +112,9 @@ public class BSONDocumentIterator: IteratorProtocol {
                 for (i, byte) in buffer.enumerated() {
                     // first byte is type of element
                     guard i != 0 else {
-                        guard let typeByte = buffer.first else {
-                            return (0, nil)
-                        }
-
-                        guard let type = BSONType(rawValue: typeByte), type != .invalid else {
+                        guard let type = BSONType(rawValue: byte), type != .invalid else {
                             return (1, nil)
                         }
-
                         bsonType = type
                         continue
                     }
@@ -174,6 +169,10 @@ public class BSONDocumentIterator: IteratorProtocol {
         return (key: key, value: bson)
     }
 
+    /// Move the reader index for the underlying buffer forward by the provided amount if possible.
+    /// Returns true if the index was moved successfully and false otherwise.
+    ///
+    /// This will only fail if the underlying buffer contains invalid BSON.
     private func moveReaderIndexSafely(forwardBy amount: Int) -> Bool {
         guard amount > 0 && self.buffer.readerIndex + amount <= self.buffer.writerIndex else {
             return false

--- a/Sources/SwiftBSON/ExtendedJSONDecoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONDecoder.swift
@@ -78,7 +78,7 @@ public class ExtendedJSONDecoder {
         case let .encodedObject(obj):
             var storage = BSONDocument.BSONDocumentStorage()
             _ = try self.appendObject(obj, to: &storage, keyPath: keyPath)
-            return .document(BSONDocument(fromUnsafeBSON: storage))
+            return .document(try BSONDocument(fromBSONWithoutValidatingElements: storage))
         }
     }
 

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -273,11 +273,17 @@ final class BSONCorpusTests: BSONTestCase {
                     }
                     expect(try BSONDocument(fromBSON: data)).to(throwError(), description: description)
 
-                    if let doc = try? BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: data)) {
+                    let buffer = BSON_ALLOCATOR.buffer(bytes: data)
+                    if var doc = try? BSONDocument(fromBSONWithoutValidatingElements: buffer) {
                         // assert that iteration doesn't crash
                         for (_, _) in doc {
                             continue
                         }
+                        // assert that appending a value doesn't crash
+                        doc["foo"] = true
+
+                        // assert that counting the elements doesn't crash
+                        _ = doc.count
                     }
                 }
             }

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -272,6 +272,13 @@ final class BSONCorpusTests: BSONTestCase {
                         return
                     }
                     expect(try BSONDocument(fromBSON: data)).to(throwError(), description: description)
+
+                    if let doc = try? BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: data)) {
+                        // assert that iteration doesn't crash
+                        for (_, _) in doc {
+                            continue
+                        }
+                    }
                 }
             }
         }

--- a/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
+++ b/Tests/SwiftBSONTests/BSONDocumentIteratorTests.swift
@@ -6,13 +6,13 @@ import XCTest
 final class DocumentIteratorTests: BSONTestCase {
     func testFindByteRangeEmpty() throws {
         let d: BSONDocument = [:]
-        let range = try BSONDocumentIterator.findByteRange(for: "item", in: d)
+        let range = BSONDocumentIterator.findByteRange(for: "item", in: d)
         expect(range).to(beNil())
     }
 
     func testFindByteRangeItemsInt32() throws {
         let d: BSONDocument = ["item0": .int32(32), "item1": .int32(32)]
-        let maybeRange = try BSONDocumentIterator.findByteRange(for: "item1", in: d)
+        let maybeRange = BSONDocumentIterator.findByteRange(for: "item1", in: d)
 
         expect(maybeRange).toNot(beNil())
         let range = maybeRange!

--- a/Tests/SwiftBSONTests/DocumentTests.swift
+++ b/Tests/SwiftBSONTests/DocumentTests.swift
@@ -884,12 +884,12 @@ final class DocumentTests: BSONTestCase {
     }
 
     func testNoElementValidation() throws {
-        let tooMany = "2300000000"
-        expect(try BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: Data(hexString: tooMany)!)))
-            .to(throwError( errorType: BSONError.InvalidArgumentError.self))
+        let tooMany = BSON_ALLOCATOR.buffer(bytes: Data(hexString: "2300000000")!)
+        expect(try BSONDocument(fromBSONWithoutValidatingElements: tooMany))
+            .to(throwError(errorType: BSONError.InvalidArgumentError.self))
 
-        let tooFew = "0B0000001069000100000000"
-        expect(try BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: Data(hexString: tooFew)!)))
-            .to(throwError( errorType: BSONError.InvalidArgumentError.self))
+        let tooFew = BSON_ALLOCATOR.buffer(bytes: Data(hexString: "0B0000001069000100000000")!)
+        expect(try BSONDocument(fromBSONWithoutValidatingElements: tooFew))
+            .to(throwError(errorType: BSONError.InvalidArgumentError.self))
     }
 }

--- a/Tests/SwiftBSONTests/DocumentTests.swift
+++ b/Tests/SwiftBSONTests/DocumentTests.swift
@@ -882,4 +882,14 @@ final class DocumentTests: BSONTestCase {
         let data = Data(hexString: hex)!
         expect(try BSONDocument(fromBSON: data)).to(throwError(errorType: BSONError.InvalidArgumentError.self))
     }
+
+    func testNoElementValidation() throws {
+        let tooMany = "2300000000"
+        expect(try BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: Data(hexString: tooMany)!)))
+            .to(throwError( errorType: BSONError.InvalidArgumentError.self))
+
+        let tooFew = "0B0000001069000100000000"
+        expect(try BSONDocument(withoutValidatingElements: BSON_ALLOCATOR.buffer(bytes: Data(hexString: tooFew)!)))
+            .to(throwError( errorType: BSONError.InvalidArgumentError.self))
+    }
 }


### PR DESCRIPTION
SWIFT-1072

This PR includes the BSON library portion of the insertion improvements. A subsequent PR on the driver repo will be opened after this one goes through.

| benchmark             | libbson based median time | target time (4x) | unoptimized swift-bson | post-optimizations |
|-----------------------|---------------------------|------------------|------------------------|--------------------|
| small doc bulk insert | 0.096                     | 0.12             | 4258.673               | 0.117              |
| large doc bulk insert | 0.332                     | 0.415            | 59.637                 | 0.454              |
| small doc insertOne   | 3.258                     | 4.0725           | 8.276                  | 3.412              |
| large doc insertOne   | 0.327                     | 0.409            | 28.742                 | 0.456              |

As noted in the design, we missed on the large doc benchmarks by a little, but those ones are still super fast compared to other MongoDB drivers, so it isn't a huge concern.