### PR TITLE
SWIFT-1086 Ignore key order in array-nested documents in equalsIgnoreKeyOrder

### DIFF
--- a/Sources/SwiftBSON/BSON.swift
+++ b/Sources/SwiftBSON/BSON.swift
@@ -494,3 +494,21 @@ extension BSON: Codable {
         try self.bsonValue.encode(to: encoder)
     }
 }
+
+extension BSON {
+    internal func equalsIgnoreKeyOrder(_ other: BSON) -> Bool {
+        switch (self, other) {
+        case let (.document(selfDoc), .document(otherDoc)):
+            return selfDoc.equalsIgnoreKeyOrder(otherDoc)
+        case let (.array(selfArr), .array(otherArr)):
+            return selfArr.elementsEqual(otherArr) {
+                $0.equalsIgnoreKeyOrder($1)
+            }
+        case let (.codeWithScope(selfCodeWithScope), .codeWithScope(otherCodeWithScope)):
+            return selfCodeWithScope.code == otherCodeWithScope.code
+                && selfCodeWithScope.scope.equalsIgnoreKeyOrder(otherCodeWithScope.scope)
+        default:
+            return self == other
+        }
+    }
+}

--- a/Sources/SwiftBSON/BSONDocument.swift
+++ b/Sources/SwiftBSON/BSONDocument.swift
@@ -570,14 +570,7 @@ extension BSONDocument {
         }
 
         for (k, v) in self {
-            let otherValue = other[k]
-            if case let (.document(docA), .document(docB)?) = (v, otherValue) {
-                guard docA.equalsIgnoreKeyOrder(docB) else {
-                    return false
-                }
-                continue
-            }
-            guard v == otherValue else {
+            guard let otherValue = other[k], v.equalsIgnoreKeyOrder(otherValue) else {
                 return false
             }
         }

--- a/Tests/SwiftBSONTests/DocumentTests.swift
+++ b/Tests/SwiftBSONTests/DocumentTests.swift
@@ -268,8 +268,8 @@ final class DocumentTests: BSONTestCase {
             "array2": ["string1", "string2"],
             "null": .null,
             "code": .code(BSONCode(code: "console.log('hi');")),
-            "nestedarray": [[1, 2], [.int32(3), .int32(4)]],
-            "codewscope": .codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["x": 2]))
+            "nestedarray": [[1, 2], [.int32(3), .int32(4)], ["x": 1, "y": 2]],
+            "codewscope": .codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["y": 1, "x": 2]))
         ]
 
         let b: BSONDocument = [
@@ -283,8 +283,8 @@ final class DocumentTests: BSONTestCase {
             "minkey": .minKey,
             "date": .datetime(Date(timeIntervalSince1970: 500.004)),
             "timestamp": .timestamp(BSONTimestamp(timestamp: 5, inc: 10)),
-            "nestedarray": [[1, 2], [.int32(3), .int32(4)]],
-            "codewscope": .codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["x": 2])),
+            "nestedarray": [[1, 2], [.int32(3), .int32(4)], ["y": 2, "x": 1]],
+            "codewscope": .codeWithScope(BSONCodeWithScope(code: "console.log(x);", scope: ["x": 2, "y": 1])),
             "nesteddoc": ["b": 2, "a": 1, "d": [3, 4], "c": false],
             "oid": .objectID(try! BSONObjectID("507f1f77bcf86cd799439011")),
             "false": false,


### PR DESCRIPTION
Fix for SWIFT-1086