### PR TITLE
SWIFT-734 Update scripts to maintain multiple versions of the documentation

### DIFF
--- a/etc/docs-main.md
+++ b/etc/docs-main.md
@@ -4,4 +4,6 @@ This is the documentation for the official MongoDB Swift BSON library, [swift-bs
 
 You can view the README for this project, including installation instructions, [here](https://github.com/mongodb/swift-bson/blob/master/README.md).
 
-The documentation for the official MongoDB Swift driver, which depends on this BSON library, can be found [here](https://mongodb.github.io/mongo-swift-driver/MongoSwift/index.html).
+Documentation for other versions of `swift-bson` can be found [here](https://mongodb.github.io/swift-bson/docs).
+
+The documentation for the official MongoDB Swift driver, which depends on `swift-bson`, can be found [here](https://mongodb.github.io/mongo-swift-driver/MongoSwift/index.html).

--- a/etc/generate-docs.sh
+++ b/etc/generate-docs.sh
@@ -9,32 +9,25 @@ if ! command -v jazzy > /dev/null; then
   gem install jazzy || { echo "ERROR: Failed to locate or install jazzy; please install yourself with 'gem install jazzy' (you may need to use sudo)"; exit 1; }
 fi
 
+if ! command -v sourcekitten > /dev/null; then
+  echo "ERROR: Failed to locate SourceKitten; please install yourself and/or add to your \$PATH"; exit 1
+fi
+
 version=${1}
 
 # Ensure version is non-empty
 [ ! -z "${version}" ] || { echo "ERROR: Missing version string"; exit 1; }
 
-jazzy \
---github-file-prefix https://github.com/mongodb/swift-bson/tree/v${version} \
---module-version "${version}" \
---output "docs-temp/SwiftBSON" \
---config .jazzy.yml
+jazzy_args=(--clean
+            --github-file-prefix https://github.com/mongodb/swift-bson/tree/v${version} 
+            --module-version "${version}")
 
-# switch to docs branch to commit and push
-git stash
-git checkout gh-pages
+sourcekitten doc --spm --module-name SwiftBSON > swift-bson-docs.json
+args=("${jazzy_args[@]}"  --output "docs-temp/SwiftBSON" --module "SwiftBSON" --config ".jazzy.yml" 
+        --sourcekitten-sourcefile swift-bson-docs.json
+        --root-url "https://mongodb.github.io/swift-bson/docs/SwiftBSON/")
+jazzy "${args[@]}"
 
-rm -rf docs/*
-cp -r docs-temp/* docs/
-rm -rf docs-temp
+echo '<html><head><meta http-equiv="refresh" content="0; url=SwiftBSON/index.html" /></head></html>' > docs-temp/index.html
 
-git add docs/
-
-echo '<html><head><meta http-equiv="refresh" content="0; url=BSON/index.html" /></head></html>' > docs/index.html
-git add docs/index.html
-
-git commit -m "${version} docs"
-git push
-
-# go back to wherever we started
-git checkout -
+rm swift-bson-docs.json

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -15,6 +15,23 @@ version=${1}
 # regenerate documentation with new version string
 ./etc/generate-docs.sh ${version}
 
+# switch to docs branch to commit and push
+git checkout gh-pages
+
+rm -r docs/current
+cp -r docs-temp docs/current
+mv docs-temp docs/${version}
+
+# build up documentation index
+python3 ./_scripts/update-index.py
+
+git add docs/
+git commit -m "${version} docs"
+git push
+
+# go back to wherever we started
+git checkout -
+
 # tag release and push tag
 git tag "v${version}"
 git push --tags


### PR DESCRIPTION
SWIFT-734

`swift-bson` equivalent of https://github.com/mongodb/mongo-swift-driver/pull/601, though this one does not erroneously commit `update-index.py`.