### PR TITLE
SWIFT-992 Update references to master branch

### DIFF
--- a/Guides/JSON-Interop.md
+++ b/Guides/JSON-Interop.md
@@ -115,8 +115,8 @@ extension ExtendedJSONDecoder: ContentDecoder {
  ```
 
 To see some example Vapor apps using the driver, check out
-[Examples/VaporExample](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/VaporExample) or 
-[Examples/ComplexVaporExample](https://github.com/mongodb/mongo-swift-driver/tree/master/Examples/ComplexVaporExample).
+[Examples/VaporExample](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/VaporExample) or
+[Examples/ComplexVaporExample](https://github.com/mongodb/mongo-swift-driver/tree/main/Examples/ComplexVaporExample).
 
 ## Using `JSONEncoder` and `JSONDecoder` with BSON Types
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Note that `BSONDocument` conforms to `Collection`, so useful methods from [`Sequ
 
 ## Development Instructions
 
-See our [development guide](https://github.com/mongodb/mongo-swift-driver/blob/master/Guides/Development.md) for the MongoDB driver to get started.
+See our [development guide](https://github.com/mongodb/mongo-swift-driver/blob/main/Guides/Development.md) for the MongoDB driver to get started.
 To run the tests for the BSON library you can make use of the Makefile and run: `make test-pretty` (uses `xcpretty` to change the output format) or just `make test` (for environments without ruby).
 
 ## Note

--- a/etc/docs-main.md
+++ b/etc/docs-main.md
@@ -2,7 +2,7 @@
 
 This is the documentation for the official MongoDB Swift BSON library, [swift-bson](https://github.com/mongodb/swift-bson).
 
-You can view the README for this project, including installation instructions, [here](https://github.com/mongodb/swift-bson/blob/master/README.md).
+You can view the README for this project, including installation instructions, [here](https://github.com/mongodb/swift-bson/blob/main/README.md).
 
 Documentation for other versions of `swift-bson` can be found [here](https://mongodb.github.io/swift-bson/docs).
 

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -5,8 +5,8 @@
 # exit if any command fails
 set -e
 
-# ensure we are on master before releasing
-git checkout master
+# ensure we are on main before releasing
+git checkout main
 
 version=${1}
 # Ensure version is non-empty


### PR DESCRIPTION
SWIFT-992

In preparation for renaming the default branch of this repository from `master` to `main`, this PR updates any existing references to the `master` branch accordingly.

I'm planning on just using the GitHub UI to rename the branch instead of creating a new one and then deleting the old one, if that's okay. See: https://github.com/github/renaming