### PR TITLE
Update package to require ioS11+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "swift-bson",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_14),
+        .iOS(.v11)
     ],
     products: [
         .library(name: "SwiftBSON", targets: ["SwiftBSON"])


### PR DESCRIPTION
When trying to import the main repo as a Swift Package for an iOS app, the Xcode build fails as Xcode believes that the package supports all versions of iOS. This change tags the package as needing iOS11+, which fixes the build issues. 

@patrickfreed is aware of this change.