### PR TITLE
SWIFT-1126 / SWIFT-1137 Add legacy extended JSON parsing, fix Date-related crashes

### DIFF
--- a/Sources/SwiftBSON/BSON.swift
+++ b/Sources/SwiftBSON/BSON.swift
@@ -23,6 +23,10 @@ public enum BSON {
     case bool(Bool)
 
     /// A BSON UTC datetime.
+    /// When serialized to actual BSON bytes, the `Date` must be representable by a 64-bit signed integer
+    /// of milliseconds since the epoch. If the `Date` cannot be represented in that manner (i.e. it is too far in the
+    /// future or too far in the past), it will be serialized as either the minimum or maximum possible `Date`,
+    /// whichever is closer.
     /// - SeeAlso: https://docs.mongodb.com/manual/reference/bson-types/#date
     case datetime(Date)
 

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -201,7 +201,7 @@ extension BSONBinary: BSONValue {
         // extended JSON v2
         case .object:
             guard obj.count == 1 else {
-                throw Swift.DecodingError.extraKeysError(
+                throw Swift.DecodingError._extraKeysError(
                     keyPath: keyPath,
                     expectedKeys: ["$binary"],
                     allKeys: Set(obj.keys)
@@ -239,7 +239,7 @@ extension BSONBinary: BSONValue {
             subtype = s
         case let .string(base64):
             guard obj.count == 2 else {
-                throw Swift.DecodingError.extraKeysError(
+                throw Swift.DecodingError._extraKeysError(
                     keyPath: keyPath,
                     expectedKeys: ["$binary"],
                     allKeys: Set(obj.keys)

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -1,4 +1,5 @@
 import ExtrasBase64
+import ExtrasJSON
 import Foundation
 import NIO
 
@@ -57,6 +58,34 @@ public struct BSONBinary: Equatable, Hashable {
                 throw BSONError.InvalidArgumentError(message: "Cannot represent \(byteValue) as Subtype")
             }
             return subtype
+        }
+
+        fileprivate init(fromJSONValue json: JSONValue, keyPath: [String]) throws {
+            let subtypeInput: String
+            let errorMsg: String
+            switch json {
+            case let .string(s):
+                errorMsg = "subtype must be a BSON binary type as a one- or two-character hex string"
+                subtypeInput = s
+            case let .number(n):
+                errorMsg = "subtype must be a BSON binary type as an integer"
+                subtypeInput = n
+            default:
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "subtype must be a BSON binary type, got \(json) instead"
+                )
+            }
+            guard
+                let subTypeInt = UInt8(subtypeInput, radix: 16),
+                let subType = Subtype(rawValue: subTypeInt)
+            else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "Could not parse `SubType` from \"\(json)\", \(errorMsg)"
+                )
+            }
+            self = subType
         }
     }
 
@@ -146,6 +175,7 @@ public struct BSONBinary: Equatable, Hashable {
 
 extension BSONBinary: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = ["$binary", "$uuid"]
+    internal static let extJSONLegacyTypeWrapperKeys: [String] = ["$type"]
 
     /*
      * Initializes a `Binary` from ExtendedJSON.
@@ -188,38 +218,104 @@ extension BSONBinary: BSONValue {
             }
         }
 
-        // canonical and relaxed extended JSON
-        guard let binary = try json.value.unwrapObject(withKey: "$binary", keyPath: keyPath) else {
+        guard case let .object(obj) = json.value, let binary = obj["$binary"] else {
             return nil
         }
-        guard
-            let (base64, subTypeInput) = try binary.unwrapObject(withKeys: "base64", "subType", keyPath: keyPath)
-        else {
+
+        let subtype: Subtype
+        let base64Str: String
+
+        switch binary {
+        // extended JSON v2
+        case .object:
+            guard obj.count == 1 else {
+                throw Swift.DecodingError.extraKeysError(
+                    keyPath: keyPath,
+                    expectedKeys: ["$binary"],
+                    allKeys: Set(obj.keys)
+                )
+            }
+            guard
+                let (base64, subTypeInput) = try binary.unwrapObject(withKeys: "base64", "subType", keyPath: keyPath)
+            else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "Missing \"base64\" or \"subType\" in \(binary)"
+                )
+            }
+            guard let b64Str = base64.stringValue else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "Could not parse `base64` from \"\(base64)\", " +
+                        "input must be a base64-encoded (with padding as =) payload as a string"
+                )
+            }
+
+            guard
+                let subtypeString = subTypeInput.stringValue,
+                let subtypeInt = UInt8(subtypeString, radix: 16),
+                let s = Subtype(rawValue: subtypeInt)
+            else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "Could not parse `SubType` from \"\(json)\", subtype must"
+                        + "be a BSON binary type as a one- or two-character hex string"
+                )
+            }
+
+            base64Str = b64Str
+            subtype = s
+        case let .string(base64):
+            guard obj.count == 2 else {
+                throw Swift.DecodingError.extraKeysError(
+                    keyPath: keyPath,
+                    expectedKeys: ["$binary"],
+                    allKeys: Set(obj.keys)
+                )
+            }
+
+            // extended JSON v1 (legacy)
+            guard let subtypeInput = obj["$type"] else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "missing \"$type\" key in BSON binary legacy extended JSON representation"
+                )
+            }
+
+            let subtypeString: String
+            if let str = subtypeInput.stringValue {
+                subtypeString = str
+            } else if case let .number(n) = subtypeInput {
+                subtypeString = n
+            } else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "expected \"$type\" to be a string or number, got \(subtypeInput) instead"
+                )
+            }
+
+            guard
+                let subtypeInt = UInt8(subtypeString, radix: 16),
+                let s = Subtype(rawValue: subtypeInt)
+            else {
+                throw Swift.DecodingError._extendedJSONError(
+                    keyPath: keyPath,
+                    debugDescription: "Could not parse `SubType` from \"\(json)\", subtype must be a BSON binary"
+                        + "type as a one-or-two character hex string or a number"
+                )
+            }
+            
+            base64Str = base64
+            subtype = s
+        default:
             throw Swift.DecodingError._extendedJSONError(
                 keyPath: keyPath,
-                debugDescription: "Missing \"base64\" or \"subType\" in \(binary)"
+                debugDescription: "expected extended JSON object for \"$binary\", got \(binary) instead"
             )
         }
-        guard let base64Str = base64.stringValue else {
-            throw Swift.DecodingError._extendedJSONError(
-                keyPath: keyPath,
-                debugDescription: "Could not parse `base64` from \"\(base64)\", " +
-                    "input must be a base64-encoded (with padding as =) payload as a string"
-            )
-        }
-        guard
-            let subTypeStr = subTypeInput.stringValue,
-            let subTypeInt = UInt8(subTypeStr, radix: 16),
-            let subType = Subtype(rawValue: subTypeInt)
-        else {
-            throw Swift.DecodingError._extendedJSONError(
-                keyPath: keyPath,
-                debugDescription: "Could not parse `SubType` from \"\(subTypeInput)\", " +
-                    "input must be a BSON binary type as a one- or two-character hex string"
-            )
-        }
+
         do {
-            self = try BSONBinary(base64: base64Str, subtype: subType)
+            self = try BSONBinary(base64: base64Str, subtype: subtype)
         } catch {
             throw Swift.DecodingError._extendedJSONError(
                 keyPath: keyPath,

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -59,34 +59,6 @@ public struct BSONBinary: Equatable, Hashable {
             }
             return subtype
         }
-
-        fileprivate init(fromJSONValue json: JSONValue, keyPath: [String]) throws {
-            let subtypeInput: String
-            let errorMsg: String
-            switch json {
-            case let .string(s):
-                errorMsg = "subtype must be a BSON binary type as a one- or two-character hex string"
-                subtypeInput = s
-            case let .number(n):
-                errorMsg = "subtype must be a BSON binary type as an integer"
-                subtypeInput = n
-            default:
-                throw Swift.DecodingError._extendedJSONError(
-                    keyPath: keyPath,
-                    debugDescription: "subtype must be a BSON binary type, got \(json) instead"
-                )
-            }
-            guard
-                let subTypeInt = UInt8(subtypeInput, radix: 16),
-                let subType = Subtype(rawValue: subTypeInt)
-            else {
-                throw Swift.DecodingError._extendedJSONError(
-                    keyPath: keyPath,
-                    debugDescription: "Could not parse `SubType` from \"\(json)\", \(errorMsg)"
-                )
-            }
-            self = subType
-        }
     }
 
     /// Initializes a `BSONBinary` instance from a `UUID`.
@@ -304,7 +276,7 @@ extension BSONBinary: BSONValue {
                         + "type as a one-or-two character hex string or a number"
                 )
             }
-            
+
             base64Str = base64
             subtype = s
         default:

--- a/Sources/SwiftBSON/BSONEncoder.swift
+++ b/Sources/SwiftBSON/BSONEncoder.swift
@@ -449,7 +449,8 @@ extension _BSONEncoder {
                     date,
                     EncodingError.Context(
                         codingPath: self.codingPath,
-                        debugDescription: "Date must be representable as an Int64 number of milliseconds since epoch")
+                        debugDescription: "Date must be representable as an Int64 number of milliseconds since epoch"
+                    )
                 )
             }
         }

--- a/Sources/SwiftBSON/BSONEncoder.swift
+++ b/Sources/SwiftBSON/BSONEncoder.swift
@@ -16,9 +16,12 @@ public class BSONEncoder {
         case deferredToDate
 
         /// Encode the `Date` as a BSON datetime object (default).
+        /// Throws an `EncodingError` if the `Date` is further away from January 1, 1970 than can be represented
+        /// by a 64-bit signed integer of milliseconds.
         case bsonDateTime
 
         /// Encode the `Date` as a 64-bit integer counting the number of milliseconds since January 1, 1970.
+        /// Throws an `EncodingError` if the `Date` is too far away from then to be represented this way.
         case millisecondsSince1970
 
         /// Encode the `Date` as a BSON double counting the number of seconds since January 1, 1970.
@@ -440,13 +443,26 @@ extension _BSONEncoder {
 
     /// Returns the date as a `BSONValue`, or nil if no values were encoded by the custom encoder strategy.
     fileprivate func boxDate(_ date: Date) throws -> BSONValue? {
+        func validateDate() throws {
+            guard date.isValidBSONDate() else {
+                throw EncodingError.invalidValue(
+                    date,
+                    EncodingError.Context(
+                        codingPath: self.codingPath,
+                        debugDescription: "Date must be representable as an Int64 number of milliseconds since epoch")
+                )
+            }
+        }
+
         switch self.options.dateEncodingStrategy {
         case .bsonDateTime:
+            try validateDate()
             return date
         case .deferredToDate:
             try date.encode(to: self)
             return self.storage.popContainer()
         case .millisecondsSince1970:
+            try validateDate()
             return date.msSinceEpoch
         case .secondsSince1970:
             return date.timeIntervalSince1970

--- a/Sources/SwiftBSON/BSONError.swift
+++ b/Sources/SwiftBSON/BSONError.swift
@@ -55,6 +55,19 @@ extension DecodingError {
             debugDescription: debugStart + debugDescription
         ))
     }
+
+    internal static func extraKeysError(
+        keyPath: [String],
+        expectedKeys: Set<String>,
+        allKeys: Set<String>
+    ) -> DecodingError {
+        let extra = allKeys.subtracting(expectedKeys)
+
+        return Self._extendedJSONError(
+            keyPath: keyPath,
+            debugDescription: "Expected only the following keys, \(Array(expectedKeys)), instead got extra key(s): \(extra)"
+        )
+    }
 }
 
 /// Standardize the errors emitted from the BSON Iterator.

--- a/Sources/SwiftBSON/BSONError.swift
+++ b/Sources/SwiftBSON/BSONError.swift
@@ -65,7 +65,8 @@ extension DecodingError {
 
         return Self._extendedJSONError(
             keyPath: keyPath,
-            debugDescription: "Expected only the following keys, \(Array(expectedKeys)), instead got extra key(s): \(extra)"
+            debugDescription: "Expected only the following keys, \(Array(expectedKeys)), instead got extra " +
+                "key(s): \(extra)"
         )
     }
 }

--- a/Sources/SwiftBSON/BSONError.swift
+++ b/Sources/SwiftBSON/BSONError.swift
@@ -56,7 +56,7 @@ extension DecodingError {
         ))
     }
 
-    internal static func extraKeysError(
+    internal static func _extraKeysError(
         keyPath: [String],
         expectedKeys: Set<String>,
         allKeys: Set<String>

--- a/Sources/SwiftBSON/BSONValue.swift
+++ b/Sources/SwiftBSON/BSONValue.swift
@@ -13,7 +13,7 @@ internal protocol BSONValue: Codable {
 
     /// The `$`-prefixed keys that indicate an object may be a legacy extended JSON object wrapper.
     /// Because these keys can conflict with query operators (e.g. "$regex"), they are not always part of
-    /// and object wrapper, and may sometimes be parsed as normal BSON.
+    /// an object wrapper and may sometimes be parsed as normal BSON.
     static var extJSONLegacyTypeWrapperKeys: [String] { get }
 
     /// Initializes a corresponding `BSON` from the provided `ByteBuffer`,

--- a/Sources/SwiftBSON/BSONValue.swift
+++ b/Sources/SwiftBSON/BSONValue.swift
@@ -11,6 +11,11 @@ internal protocol BSONValue: Codable {
     /// for this `BSONValue`. (e.g. for Int32, this value is ["$numberInt"]).
     static var extJSONTypeWrapperKeys: [String] { get }
 
+    /// The `$`-prefixed keys that indicate an object may be a legacy extended JSON object wrapper.
+    /// Because these keys can conflict with query operators (e.g. "$regex"), they are not always part of
+    /// and object wrapper, and may sometimes be parsed as normal BSON.
+    static var extJSONLegacyTypeWrapperKeys: [String] { get }
+
     /// Initializes a corresponding `BSON` from the provided `ByteBuffer`,
     /// moving the buffer's readerIndex forward to the byte beyond the end
     /// of this value.
@@ -35,6 +40,8 @@ internal protocol BSONValue: Codable {
 
 /// Convenience extension to get static bsonType from an instance
 extension BSONValue {
+    internal static var extJSONLegacyTypeWrapperKeys: [String] { [] }
+
     internal var bsonType: BSONType {
         Self.bsonType
     }

--- a/Sources/SwiftBSON/Date+BSONValue.swift
+++ b/Sources/SwiftBSON/Date+BSONValue.swift
@@ -56,7 +56,8 @@ extension Date: BSONValue {
             guard let msInt64 = Int64(ms) else {
                 throw DecodingError._extendedJSONError(
                     keyPath: keyPath,
-                    debugDescription: "Expected \(ms) to be valid Int64 representing milliseconds since epoch")
+                    debugDescription: "Expected \(ms) to be valid Int64 representing milliseconds since epoch"
+                )
             }
             self = Date(msSinceEpoch: msInt64)
         default:

--- a/Sources/SwiftBSON/ExtendedJSONDecoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONDecoder.swift
@@ -17,8 +17,15 @@ public class ExtendedJSONDecoder {
     }()
 
     /// A set of all the possible extendedJSON wrapper keys.
+    /// This does not include the legacy extended JSON wrapper keys.
     private static var wrapperKeySet: Set<String> = {
-        Set(ExtendedJSONDecoder.wrapperKeyMap.keys)
+        var keys: Set<String> = []
+        for t in BSON.allBSONTypes.values {
+            for k in t.extJSONTypeWrapperKeys {
+                keys.insert(k)
+            }
+        }
+        return keys
     }()
 
     /// A map from extended JSON wrapper keys (e.g. "$numberLong") to the BSON type(s) that they correspond to.
@@ -31,6 +38,9 @@ public class ExtendedJSONDecoder {
         var map: [String: [BSONValue.Type]] = [:]
         for t in BSON.allBSONTypes.values {
             for k in t.extJSONTypeWrapperKeys {
+                map[k, default: []].append(t.self)
+            }
+            for k in t.extJSONLegacyTypeWrapperKeys {
                 map[k, default: []].append(t.self)
             }
         }

--- a/Sources/SwiftBSON/JSON.swift
+++ b/Sources/SwiftBSON/JSON.swift
@@ -7,12 +7,6 @@ internal struct JSON {
     internal init(_ value: JSONValue) {
         self.value = value
     }
-
-    internal func toString() -> String {
-        var bytes: [UInt8] = []
-        self.value.appendBytes(to: &bytes)
-        return String(data: Data(bytes), encoding: .utf8)!
-    }
 }
 
 extension JSON: Encodable {

--- a/Sources/SwiftBSON/JSON.swift
+++ b/Sources/SwiftBSON/JSON.swift
@@ -135,10 +135,7 @@ extension JSONValue {
             return nil
         }
         guard obj.count == 1 else {
-            throw DecodingError._extendedJSONError(
-                keyPath: keyPath,
-                debugDescription: "Expected only \"\(key)\", found too many keys: \(obj.keys)"
-            )
+            throw DecodingError._extraKeysError(keyPath: keyPath, expectedKeys: [key], allKeys: Set(obj.keys))
         }
         return value
     }
@@ -173,10 +170,7 @@ extension JSONValue {
             return nil
         }
         guard obj.count == 2 else {
-            throw DecodingError._extendedJSONError(
-                keyPath: keyPath,
-                debugDescription: "Expected only \"\(key1)\" and \"\(key2)\" found keys: \(obj.keys)"
-            )
+            throw DecodingError._extraKeysError(keyPath: keyPath, expectedKeys: [key1, key2], allKeys: Set(obj.keys))
         }
         return (value1, value2)
     }

--- a/Sources/SwiftBSON/JSON.swift
+++ b/Sources/SwiftBSON/JSON.swift
@@ -7,6 +7,12 @@ internal struct JSON {
     internal init(_ value: JSONValue) {
         self.value = value
     }
+
+    internal func toString() -> String {
+        var bytes: [UInt8] = []
+        self.value.appendBytes(to: &bytes)
+        return String(data: Data(bytes), encoding: .utf8)!
+    }
 }
 
 extension JSON: Encodable {

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -121,7 +121,9 @@ final class BSONCorpusTests: BSONTestCase {
                 ],
             "Top-level document validity": [
                 "Bad DBRef (ref is number, not string)",
-                "Bad DBRef (db is number, not string)"
+                "Bad DBRef (db is number, not string)",
+                // SWIFT-1138: legacy extended JSON $date syntax uses numbers
+                "Bad $date (number, not string or hash)"
             ]
         ]
 
@@ -177,6 +179,7 @@ final class BSONCorpusTests: BSONTestCase {
                             .to(cleanEqual(rEJ), description: test.description)
                     }
 
+                    print(test.description)
                     // for cEJ input:
                     // native_to_canonical_extended_json( json_to_native(cEJ) ) = cEJ
                     expect(try canonicalEncoder.encode(try decoder.decode(BSONDocument.self, from: cEJData)))

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -179,7 +179,6 @@ final class BSONCorpusTests: BSONTestCase {
                             .to(cleanEqual(rEJ), description: test.description)
                     }
 
-                    print(test.description)
                     // for cEJ input:
                     // native_to_canonical_extended_json( json_to_native(cEJ) ) = cEJ
                     expect(try canonicalEncoder.encode(try decoder.decode(BSONDocument.self, from: cEJData)))

--- a/Tests/SwiftBSONTests/BSONValueTests.swift
+++ b/Tests/SwiftBSONTests/BSONValueTests.swift
@@ -187,7 +187,7 @@ final class BSONValueTests: BSONTestCase {
         // Since we can't throw here, expect the date to be clamped to the max date.
         // Note: since Swift represents datetimes using floating point numbers, this won't be an exact comparison,
         // since many large numbers can't be represented exactly by Swift Doubles
-        let doc: BSONDocument = ["x": .datetime(bigDate) ]
+        let doc: BSONDocument = ["x": .datetime(bigDate)]
         expect(doc["x"]).to(equal(.datetime(Date(msSinceEpoch: Int64.max))))
         let smallDoc: BSONDocument = ["x": .datetime(smallDate)]
         expect(smallDoc["x"]).to(equal(.datetime(Date(msSinceEpoch: Int64.min))))
@@ -196,7 +196,7 @@ final class BSONValueTests: BSONTestCase {
         struct D: Codable {
             let date: Date
         }
-        var encoder = try BSONEncoder()
+        let encoder = BSONEncoder()
         expect(try encoder.encode(D(date: bigDate))).to(throwError(errorType: EncodingError.self))
         expect(try encoder.encode(D(date: smallDate))).to(throwError(errorType: EncodingError.self))
 

--- a/Tests/SwiftBSONTests/BSONValueTests.swift
+++ b/Tests/SwiftBSONTests/BSONValueTests.swift
@@ -175,4 +175,33 @@ final class BSONValueTests: BSONTestCase {
 
         cases.forEach { $0.run() }
     }
+
+    func testBigDate() throws {
+        // Verify big dates (bigger than fit in BSON) don't crash.
+
+        // These are in _seconds_ since epoch, which is way bigger than can be encoded in BSON, which
+        // is milliseconds.
+        let bigDate = Date(timeIntervalSince1970: TimeInterval(Int64.max))
+        let smallDate = Date(timeIntervalSince1970: TimeInterval(Int64.min))
+
+        // Since we can't throw here, expect the date to be clamped to the max date.
+        // Note: since Swift represents datetimes using floating point numbers, this won't be an exact comparison,
+        // since many large numbers can't be represented exactly by Swift Doubles
+        let doc: BSONDocument = ["x": .datetime(bigDate) ]
+        expect(doc["x"]).to(equal(.datetime(Date(msSinceEpoch: Int64.max))))
+        let smallDoc: BSONDocument = ["x": .datetime(smallDate)]
+        expect(smallDoc["x"]).to(equal(.datetime(Date(msSinceEpoch: Int64.min))))
+
+        // When encoding, throw for date that can't be represented.
+        struct D: Codable {
+            let date: Date
+        }
+        var encoder = try BSONEncoder()
+        expect(try encoder.encode(D(date: bigDate))).to(throwError(errorType: EncodingError.self))
+        expect(try encoder.encode(D(date: smallDate))).to(throwError(errorType: EncodingError.self))
+
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        expect(try encoder.encode(D(date: smallDate))).to(throwError(errorType: EncodingError.self))
+        expect(try encoder.encode(D(date: smallDate))).to(throwError(errorType: EncodingError.self))
+    }
 }

--- a/Tests/SwiftBSONTests/CommonTestUtils.swift
+++ b/Tests/SwiftBSONTests/CommonTestUtils.swift
@@ -106,3 +106,11 @@ public func rearrangeDoc(_ input: BSONDocument, toLookLike standard: BSONDocumen
     }
     return output
 }
+
+extension JSON {
+    internal func toString() -> String {
+        var bytes: [UInt8] = []
+        self.value.appendBytes(to: &bytes)
+        return String(data: Data(bytes), encoding: .utf8)!
+    }
+}

--- a/Tests/SwiftBSONTests/CommonTestUtils.swift
+++ b/Tests/SwiftBSONTests/CommonTestUtils.swift
@@ -62,6 +62,25 @@ public func sortedEqual(_ expectedValue: BSONDocument?) -> Predicate<BSONDocumen
     }
 }
 
+public func sortedEqual(_ expectedValue: BSON?) -> Predicate<BSON> {
+    Predicate.define("sortedEqual <\(stringify(expectedValue))>") { actualExpression, msg in
+        let actualValue = try actualExpression.evaluate()
+
+        guard let expected = expectedValue, let actual = actualValue else {
+            if expectedValue == nil && actualValue != nil {
+                return PredicateResult(
+                    status: .fail,
+                    message: msg.appendedBeNilHint()
+                )
+            }
+            return PredicateResult(status: .fail, message: msg)
+        }
+
+        let matches = expected.equalsIgnoreKeyOrder(actual)
+        return PredicateResult(status: PredicateStatus(bool: matches), message: msg)
+    }
+}
+
 /// Given two documents, returns a copy of the input document with all keys that *don't*
 /// exist in `standard` removed, and with all matching keys put in the same order they
 /// appear in `standard`.

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -695,9 +695,11 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
     }
 
     func testLegacyExtendedJSONRegex() throws {
+        let regex = BSONRegularExpression(pattern: "abc", options: "ix")
+
         Self.jsonTest(
             json: ["val": ["$regex": "abc", "$options": "ix"]],
-            expectation: .success(BSONRegularExpression(pattern: "abc", options: "ix"))
+            expectation: .success(regex)
         )
 
         // // don't invalidate a "$regex" query operator stored in JSON
@@ -712,6 +714,10 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
         Self.jsonTest(
             json: ["val": ["$regex": "abc", "$options": "ix", "extra": true]],
             expectation: .success(["$regex": "abc", "$options": "ix", "extra": true] as BSONDocument)
+        )
+        Self.jsonTest(
+            json: ["val": ["$regex": ["$regularExpression": ["pattern": "abc", "options": "ix"]]]],
+            expectation: .success(["$regex": .regex(regex)] as BSONDocument)
         )
     }
 }

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -702,7 +702,7 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             expectation: .success(regex)
         )
 
-        // // don't invalidate a "$regex" query operator stored in JSON
+        // don't invalidate a "$regex" query operator stored in JSON
         Self.jsonTest(
             json: ["val": ["$regex": "abc"]],
             expectation: .success(["$regex": "abc"] as BSONDocument)

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -554,7 +554,7 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
     /// matches the provided expectation.
     /// For tests verifying successful behavior, the value of the "val" field in the resultant document
     /// is compared with the expectation.
-    func jsonTest<T: BSONValue>(json: JSON, expectation: Expectation<T>) {
+    static func jsonTest<T: BSONValue>(json: JSON, expectation: Expectation<T>) {
         do {
             let doc = try BSONDocument(fromJSON: json.toString())
             guard case let .success(expected) = expectation else {
@@ -573,36 +573,36 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
     func testLegacyExtendedJSONBinary() throws {
         let base64 = "CjJecTUqS7y4e3X8Cz4ZcQ=="
         let binary = try BSONBinary(base64: base64, subtype: .uuid)
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
                     "$type": 4
-                ],
+                ]
             ],
             expectation: .success(binary)
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
                     "$type": "4"
                 ]
             ],
-            expectation: .success(binary) 
+            expectation: .success(binary)
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
-                    "$type": "4",
+                    "$type": "4"
                 ]
             ],
             expectation: .success(["$type": "4"] as BSONDocument)
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
@@ -613,7 +613,7 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             expectation: .error()
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
@@ -623,7 +623,7 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             expectation: .error()
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
@@ -633,7 +633,7 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             expectation: .error()
         )
 
-        jsonTest(
+        Self.jsonTest(
             json: [
                 "val": [
                     "$binary": JSON(.string(base64)),
@@ -647,69 +647,69 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             "$binary": JSON(.string(base64)),
             "$type": "hello"
         ]
-        jsonTest(json: invalidStringSubtype, expectation: .error())
+        Self.jsonTest(json: invalidStringSubtype, expectation: .error())
 
         let invalidStringNumberSubtype: JSON = [
             "$binary": JSON(.string(base64)),
             "$type": "12345"
         ]
-        jsonTest(json: invalidStringNumberSubtype, expectation: .error())
+        Self.jsonTest(json: invalidStringNumberSubtype, expectation: .error())
     }
 
     func testLegacyExtendedJSONDate() throws {
-        jsonTest(json: ["val": ["$date": 0]], expectation: .success(Date(timeIntervalSince1970: 0)))
-        jsonTest(
-            json: [ "val": ["$date": 1356351330500]],
-            expectation: .success(Date(msSinceEpoch: 1356351330500))
+        Self.jsonTest(json: ["val": ["$date": 0]], expectation: .success(Date(timeIntervalSince1970: 0)))
+        Self.jsonTest(
+            json: ["val": ["$date": 1_356_351_330_500]],
+            expectation: .success(Date(msSinceEpoch: 1_356_351_330_500))
         )
-        jsonTest(
-            json: ["val": ["$date": -62135593139000]],
-            expectation: .success(Date(msSinceEpoch: -62135593139000))
+        Self.jsonTest(
+            json: ["val": ["$date": -62_135_593_139_000]],
+            expectation: .success(Date(msSinceEpoch: -62_135_593_139_000))
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number(String(Int64.max)))]],
             expectation: .success(Date(msSinceEpoch: Int64.max))
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number(String(Int64.min)))]],
             expectation: .success(Date(msSinceEpoch: Int64.min))
         )
         // Int64.max + 1
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number("9223372036854775808"))]],
             expectation: .error()
         )
         // Int64.min - 1
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number("-9223372036854775809"))]],
             expectation: .error()
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number("10000000000000000000"))]],
             expectation: .error()
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$date": JSON(.number("-10000000000000000000"))]],
             expectation: .error()
         )
     }
 
     func testLegacyExtendedJSONRegex() throws {
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$regex": "abc", "$options": "ix"]],
             expectation: .success(BSONRegularExpression(pattern: "abc", options: "ix"))
         )
 
         // // don't invalidate a "$regex" query operator stored in JSON
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$regex": "abc"]],
             expectation: .success(["$regex": "abc"] as BSONDocument)
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$options": "abc"]],
             expectation: .success(["$options": "abc"] as BSONDocument)
         )
-        jsonTest(
+        Self.jsonTest(
             json: ["val": ["$regex": "abc", "$options": "ix", "extra": true]],
             expectation: .success(["$regex": "abc", "$options": "ix", "extra": true] as BSONDocument)
         )


### PR DESCRIPTION
SWIFT-1126 / SWIFT-1137

This PR adds support for legacy extended JSON v1 parsing, which the old libbson-based BSON library had support for. This PR also fixes potential crashes that may occur when trying to use `Date` values extremely far in the future (> `Int64.max` ms from epoch) or the past (< `Int64.min` ms before epoch).