### PR TITLE
SWIFT-1107, SWIFT-964: BSON corpus test updates

### DIFF
--- a/Tests/Specs/bson-corpus/dbref.json
+++ b/Tests/Specs/bson-corpus/dbref.json
@@ -1,5 +1,5 @@
 {
-    "description": "DBRef",
+    "description": "Document type (DBRef sub-documents)",
     "bson_type": "0x03",
     "valid": [
         {
@@ -26,6 +26,26 @@
             "description": "Document with key names similar to those of a DBRef",
             "canonical_bson": "3e0000000224726566000c0000006e6f742d612d646272656600072469640058921b3e6e32ab156a22b59e022462616e616e6100050000007065656c0000",
             "canonical_extjson": "{\"$ref\": \"not-a-dbref\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$banana\": \"peel\"}"
+        },
+        {
+            "description": "DBRef with additional dollar-prefixed and dotted fields",
+            "canonical_bson": "48000000036462726566003c0000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e10612e62000100000010246300010000000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"a.b\": {\"$numberInt\": \"1\"}, \"$c\": {\"$numberInt\": \"1\"}}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $id is missing",
+            "canonical_bson": "26000000036462726566001a0000000224726566000b000000636f6c6c656374696f6e000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\"}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $ref is not a string",
+            "canonical_bson": "2c000000036462726566002000000010247265660001000000072469640058921b3e6e32ab156a22b59e0000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}}}"
+        },
+        {
+            "description": "Sub-document resembles DBRef but $db is not a string",
+            "canonical_bson": "4000000003646272656600340000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e1024646200010000000000",
+            "canonical_extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$db\": {\"$numberInt\": \"1\"}}}"
         }
     ]
 }

--- a/Tests/Specs/bson-corpus/document.json
+++ b/Tests/Specs/bson-corpus/document.json
@@ -17,6 +17,26 @@
             "description": "Single-character key subdoc",
             "canonical_bson": "160000000378000E0000000261000200000062000000",
             "canonical_extjson": "{\"x\" : {\"a\" : \"b\"}}"
+        },
+        {
+            "description": "Dollar-prefixed key in sub-document",
+            "canonical_bson": "170000000378000F000000022461000200000062000000",
+            "canonical_extjson": "{\"x\" : {\"$a\" : \"b\"}}"
+        },
+        {
+            "description": "Dollar as key in sub-document",
+            "canonical_bson": "160000000378000E0000000224000200000061000000",
+            "canonical_extjson": "{\"x\" : {\"$\" : \"a\"}}"
+        },
+        {
+            "description": "Dotted key in sub-document",
+            "canonical_bson": "180000000378001000000002612E62000200000063000000",
+            "canonical_extjson": "{\"x\" : {\"a.b\" : \"c\"}}"
+        },
+        {
+            "description": "Dot as key in sub-document",
+            "canonical_bson": "160000000378000E000000022E000200000061000000",
+            "canonical_extjson": "{\"x\" : {\".\" : \"a\"}}"
         }
     ],
     "decodeErrors": [

--- a/Tests/Specs/bson-corpus/top.json
+++ b/Tests/Specs/bson-corpus/top.json
@@ -3,9 +3,24 @@
     "bson_type": "0x00",
     "valid": [
         {
-            "description": "Document with keys that start with $",
+            "description": "Dollar-prefixed key in top-level document",
             "canonical_bson": "0F00000010246B6579002A00000000",
             "canonical_extjson": "{\"$key\": {\"$numberInt\": \"42\"}}"
+        },
+        {
+            "description": "Dollar as key in top-level document",
+            "canonical_bson": "0E00000002240002000000610000",
+            "canonical_extjson": "{\"$\": \"a\"}"
+        },
+        {
+            "description": "Dotted key in top-level document",
+            "canonical_bson": "1000000002612E620002000000630000",
+            "canonical_extjson": "{\"a.b\": \"c\"}"
+        },
+        {
+            "description": "Dot as key in top-level document",
+            "canonical_bson": "0E000000022E0002000000610000",
+            "canonical_extjson": "{\".\": \"a\"}"
         }
     ],
     "decodeErrors": [
@@ -198,14 +213,6 @@
         {
             "description": "Bad $date (extra field)",
             "string": "{\"a\" : {\"$date\" : {\"$numberLong\" : \"1356351330501\"}, \"unrelated\": true}}"
-        },
-        {
-            "description": "Bad DBRef (ref is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : 42, \"$id\" : \"abc\"}}"
-        },
-        {
-            "description": "Bad DBRef (db is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : \"a\", \"$id\" : \"abc\", \"$db\" : 42}}"
         },
         {
             "description": "Bad $minKey (boolean, not integer)",

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -192,9 +192,10 @@ final class BSONCorpusTests: BSONTestCase {
 
                         let docFromDB = try BSONDocument(fromBSON: dBData)
 
-                        // SKIPPING: native_to_bson( bson_to_native(dB) ) = cB
-                        // We only validate the BSON bytes, we do not clean them up, so can't do this assertion
-                        // Degenerate BSON round trip tests will be added in SWIFT-964
+                        // native_to_bson( bson_to_native(dB) ) = cB
+                        let nativeFromDoc = docFromDB.toArray()
+                        let docFromNative = BSONDocument(fromArray: nativeFromDoc)
+                        expect(docFromNative.toByteString()).to(equal(cBData.toByteString()))
 
                         // native_to_canonical_extended_json( bson_to_native(dB) ) = cEJ
                         // (Not in spec yet, might be added in DRIVERS-1355)

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -112,13 +112,6 @@ final class BSONCorpusTests: BSONTestCase {
                     // TODO: SWIFT-972
                     "Special - Negative NaN"
                 ],
-            "Array":
-                [
-                    // TODO: SWIFT-963
-                    "Multi Element Array with duplicate indexes",
-                    "Single Element Array with index set incorrectly to empty string",
-                    "Single Element Array with index set incorrectly to ab"
-                ],
             "Top-level document validity": [
                 "Bad DBRef (ref is number, not string)",
                 "Bad DBRef (db is number, not string)",


### PR DESCRIPTION
* Sync BSON corpus test changes made as part of the "Mitigate pain of using field names with dots and dollars" project (SWIFT-1107)
* I noticed that SWIFT-963 seems to be "gone away" as the tests all pass; so added SWIFT-964 assertions to round trip degenerate BSON through native types