### PR TITLE
SWIFT-871, SWIFT-1340: Evergreen config updates

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -102,6 +102,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           SWIFT_VERSION=${SWIFT_VERSION} \
+          SANITIZE=${SANITIZE} \
           ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   
   "upload test results":
@@ -135,13 +136,13 @@ axes:
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
 
-      - id: ubuntu-16.04
-        display_name: "Ubuntu 16.04"
-        run_on: ubuntu1604-test
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04"
+        run_on: ubuntu2004-test
 
-      - id: macos-10.14
-        display_name: "macOS 10.14"
-        run_on: macos-1014
+      - id: macos-10.15
+        display_name: "macOS 10.15"
+        run_on: macos-1015
 
   - id: swift-version
     display_name: "Swift"
@@ -157,7 +158,27 @@ axes:
       - id: "5.3"
         display_name: "Swift 5.3"
         variables:
-          SWIFT_VERSION: "5.3"
+          SWIFT_VERSION: "5.3.3"
+      - id: "5.4"
+        display_name: "Swift 5.4"
+        variables:
+          SWIFT_VERSION: "5.4.2"
+      - id: "5.5-dev"
+        display_name: "Swift 5.5-dev"
+        variables:
+          SWIFT_VERSION: "DEVELOPMENT-SNAPSHOT-2021-04-26-a"
+
+  - id: sanitize
+    display_name: Sanitize
+    values:
+      - id: tsan
+        display_name: TSan
+        variables:
+          SANITIZE: "thread"
+      - id: asan
+        display_name: ASan
+        variables:
+          SANITIZE: "address"
 
 buildvariants:
   - matrix_name: "tests-all"
@@ -165,21 +186,22 @@ buildvariants:
     matrix_spec:
       os-fully-featured: "*"
       swift-version:
-        - "5.1"
         - "5.2"
+        - "5.3"
+        - "5.4"
+        - "5.5-dev"
     tasks:
       - name: "test"
 
-# define a separate matrix for 5.3 - no way to remove 5.3 + macOS from the definition above.
-# see EVG-13092
-  - matrix_name: "tests-all-5.3"
+  - matrix_name: "tests-5.1"
     display_name: "${swift-version} ${os-fully-featured}"
     matrix_spec:
+      # Swift 5.1 does not have Ubuntu 20.04 toolchains
       os-fully-featured:
         - "ubuntu-18.04"
-        - "ubuntu-16.04"
+        - "macos-10.15"
       swift-version:
-        - "5.3"
+        - "5.1"
     tasks:
       - name: "test"
 
@@ -187,7 +209,16 @@ buildvariants:
     display_name: "Format and Lint"
     matrix_spec:
       os-fully-featured: "ubuntu-18.04"
-      swift-version: "5.2"
+      swift-version: "5.4"
     tasks:
       - name: "check-format"
       - name: "check-lint"
+
+  - matrix_name: "sanitize"
+    display_name: "${sanitize} ${os-fully-featured}"
+    matrix_spec:
+      os-fully-featured: "ubuntu-18.04"
+      swift-version: "5.4"
+      sanitize: "*"
+    tasks:
+      - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -103,6 +103,7 @@ functions:
           ${PREPARE_SHELL}
           SWIFT_VERSION=${SWIFT_VERSION} \
           SANITIZE=${SANITIZE} \
+          CHECK_LEAKS=${CHECK_LEAKS} \
           ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
   
   "upload test results":
@@ -182,6 +183,14 @@ axes:
       #   variables:
       #     SANITIZE: "address"
 
+  - id: check-leaks
+    display_name: Check Leaks
+    values:
+      - id: leaks
+        display_name: Leaks
+        variables:
+          CHECK_LEAKS: leaks
+
 buildvariants:
   - matrix_name: "tests-all"
     display_name: "${swift-version} ${os-fully-featured}"
@@ -222,5 +231,14 @@ buildvariants:
       os-fully-featured: "ubuntu-18.04"
       swift-version: "5.4"
       sanitize: "tsan"
+    tasks:
+      - name: "test"
+
+  - matrix_name: "leaks"
+    display_name: "Leak Checker ${os-fully-featured}"
+    matrix_spec:
+      os-fully-featured: "macos-10.15"
+      swift-version: "5.4"
+      check-leaks: "leaks"
     tasks:
       - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -221,6 +221,6 @@ buildvariants:
     matrix_spec:
       os-fully-featured: "ubuntu-18.04"
       swift-version: "5.4"
-      sanitize: "thread"
+      sanitize: "tsan"
     tasks:
       - name: "test"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,10 +175,12 @@ axes:
         display_name: TSan
         variables:
           SANITIZE: "thread"
-      - id: asan
-        display_name: ASan
-        variables:
-          SANITIZE: "address"
+      # ASan is unfortunately known to produce false positives in Swift, see
+      # https://forums.swift.org/t/test-for-memory-leaks-in-ci/36526/9 
+      # - id: asan
+      #   display_name: ASan
+      #   variables:
+      #     SANITIZE: "address"
 
 buildvariants:
   - matrix_name: "tests-all"
@@ -219,6 +221,6 @@ buildvariants:
     matrix_spec:
       os-fully-featured: "ubuntu-18.04"
       swift-version: "5.4"
-      sanitize: "*"
+      sanitize: "thread"
     tasks:
       - name: "test"

--- a/.evergreen/install-tools.sh
+++ b/.evergreen/install-tools.sh
@@ -6,7 +6,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 # variables
 PROJECT_DIRECTORY=${PROJECT_DIRECTORY:-$PWD}
-SWIFT_VERSION=${SWIFT_VERSION:-5.2.4}
+SWIFT_VERSION=${SWIFT_VERSION:-5.4.2}
 INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
@@ -39,7 +39,7 @@ swiftenv local $SWIFT_VERSION
 
 if [ $1 == "swiftlint" ]
 then
-    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.41.0"
+    build_from_gh swiftlint https://github.com/realm/SwiftLint "0.43.1"
 elif [ $1 == "swiftformat" ]
 then
     build_from_gh swiftformat https://github.com/nicklockwood/SwiftFormat "0.47.3"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -9,6 +9,7 @@ INSTALL_DIR="${PROJECT_DIRECTORY}/opt"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 RAW_TEST_RESULTS="${PROJECT_DIRECTORY}/rawTestResults"
 XML_TEST_RESULTS="${PROJECT_DIRECTORY}/testResults.xml"
+SANITIZE=${SANITIZE:-"false"}
 
 # enable swiftenv
 export SWIFTENV_ROOT="${INSTALL_DIR}/swiftenv"
@@ -20,11 +21,16 @@ if [ "$OS" == "darwin" ]; then
     sudo xcode-select -s /Applications/Xcode11.3.app
 fi
 
+SANITIZE_STATEMENT=""
+if [ "$SANITIZE" != "false" ]; then
+    SANITIZE_STATEMENT="--sanitize ${SANITIZE}"
+fi
+
 # switch swift version, and run tests
 swiftenv local $SWIFT_VERSION
 
 # build the driver
-swift build
+swift build $SANITIZE_STATEMENT
 
 # even if tests fail we want to parse the results, so disable errexit
 set +o errexit
@@ -32,7 +38,7 @@ set +o errexit
 set -o pipefail
 
 # test the driver
-swift test --enable-test-discovery 2>&1 | tee ${RAW_TEST_RESULTS}
+swift test --enable-test-discovery $SANITIZE_STATEMENT 2>&1 | tee ${RAW_TEST_RESULTS}
 
 # save tests exit code
 EXIT_CODE=$?

--- a/Tests/SwiftBSONTests/LeakCheckTests.swift
+++ b/Tests/SwiftBSONTests/LeakCheckTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+final class LeakCheckTests: BSONTestCase {
+    func testLeaks() throws {
+        guard let checkForLeaks = ProcessInfo.processInfo.environment["CHECK_LEAKS"], checkForLeaks == "leaks" else {
+            return
+        }
+
+        // inspired by https://forums.swift.org/t/test-for-memory-leaks-in-ci/36526/19
+        atexit {
+            func leaks() -> Process {
+                let p = Process()
+                p.launchPath = "/usr/bin/leaks"
+                p.arguments = ["\(getpid())"]
+                p.launch()
+                p.waitUntilExit()
+                return p
+            }
+            let p = leaks()
+            print("================")
+            guard p.terminationReason == .exit && [0, 1].contains(p.terminationStatus) else {
+                print("Leak checking process exited unexpectedly - " +
+                    "reason: \(p.terminationReason), status: \(p.terminationStatus)")
+                exit(255)
+            }
+            if p.terminationStatus == 1 {
+                print("Unexpectedly leaked memory")
+            } else {
+                print("No memory leaks!")
+            }
+            exit(p.terminationStatus)
+        }
+    }
+}


### PR DESCRIPTION
* Test on Ubuntu 20.04 rather than 16.04
* Test on macOS 10.15 rather than 10.14
* Add testing on Swift 5.4 and 5.5-dev
* Add TSan task
* bump Swift version used for format/lint and bump SwiftLint version accordingly