### PR TITLE
Decouple BSONEncoder internals from BSONValue protocol

### DIFF
--- a/Sources/SwiftBSON/BSONEncoder.swift
+++ b/Sources/SwiftBSON/BSONEncoder.swift
@@ -760,18 +760,19 @@ extension _BSONEncoder: SingleValueEncodingContainer {
     }
 }
 
+/// Indicates that a type can be converted to a `BSON`.
 internal protocol BSONRepresentable {
     func toBSON() throws -> BSON
 }
 
 extension Array: BSONRepresentable where Element == BSON {
-    internal func toBSON() throws -> BSON {
+    internal func toBSON() -> BSON {
         .array(self)
     }
 }
 
 extension BSONValue {
-    internal func toBSON() throws -> BSON {
+    internal func toBSON() -> BSON {
         self.bson
     }
 }

--- a/Sources/SwiftBSON/BSONValue.swift
+++ b/Sources/SwiftBSON/BSONValue.swift
@@ -1,6 +1,6 @@
 import NIO
 
-internal protocol BSONValue: Codable {
+internal protocol BSONValue: Codable, BSONRepresentable {
     /// The `BSONType` associated with this value.
     static var bsonType: BSONType { get }
 


### PR DESCRIPTION
This is the way this code should have been in the first place, I think 🙂

Previously, we used the `BSONValue` protocol as the intermediate representation of data types stored in the encoder before the final conversion to BSON. However, the only requirement we actually needed from the protocol was the `.bson` property. 

As a result, our internal data structures `MutableDictionary` and `MutableArray` had to conform to `BSONValue`.

This refactor introduces a new `BSONRepresentable` profile that is used throughout the encoder in place of `BSONValue` that actually expresses what we need for encoding purposes - the ability for a type to be converted to BSON.

This is a precursor to work to fix the null bytes issue, will expand in comments.