### PR TITLE
SWIFT-1260 Disallow embedded null bytes in BSON keys

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "2b1809051b4a65c1d7f5233331daa24572cd7fca",
-          "version": "8.1.1"
+          "revision": "7a46a5fc86cb917f69e3daf79fcb045283d8f008",
+          "version": "8.1.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "120acb15c39aa3217e9888e515de160378fbcc1e",
-          "version": "2.18.0"
+          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
+          "version": "2.33.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,6 @@ let package = Package(
     ],
     targets: [
         .target(name: "SwiftBSON", dependencies: ["NIO", "ExtrasJSON", "ExtrasBase64"]),
-        .testTarget(name: "SwiftBSONTests", dependencies: ["SwiftBSON", "Nimble"])
+        .testTarget(name: "SwiftBSONTests", dependencies: ["SwiftBSON", "Nimble", "ExtrasJSON"])
     ]
 )

--- a/Sources/SwiftBSON/BSON.swift
+++ b/Sources/SwiftBSON/BSON.swift
@@ -450,7 +450,11 @@ extension BSON: ExpressibleByBooleanLiteral {
 
 extension BSON: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (String, BSON)...) {
-        self = .document(BSONDocument(dictionaryLiteral: elements))
+        do {
+            self = .document(try BSONDocument(dictionaryLiteral: elements))
+        } catch {
+            fatalError("\(error)")
+        }
     }
 }
 

--- a/Sources/SwiftBSON/BSONDocument.swift
+++ b/Sources/SwiftBSON/BSONDocument.swift
@@ -187,7 +187,6 @@ public struct BSONDocument {
             } catch {
                 fatalError("\(error)")
             }
-            
         }
     }
 

--- a/Sources/SwiftBSON/BSONEncoder.swift
+++ b/Sources/SwiftBSON/BSONEncoder.swift
@@ -846,7 +846,7 @@ private class MutableDictionary: BSONRepresentable {
         var doc = BSONDocument()
         for i in 0..<self.keys.count {
             let value = self.values[i]
-            doc.append(key: self.keys[i], value: try value.toBSON())
+            try doc.append(key: self.keys[i], value: try value.toBSON())
         }
         return doc
     }

--- a/Sources/SwiftBSON/BSONValue.swift
+++ b/Sources/SwiftBSON/BSONValue.swift
@@ -22,7 +22,7 @@ internal protocol BSONValue: Codable, BSONRepresentable {
     static func read(from buffer: inout ByteBuffer) throws -> BSON
 
     /// Writes this value's BSON byte representation to the provided ByteBuffer.
-    func write(to buffer: inout ByteBuffer)
+    func write(to buffer: inout ByteBuffer) throws
 
     /// Initializes a corresponding `BSONValue` from the provided extendedJSON.
     init?(fromExtJSON json: JSON, keyPath: [String]) throws

--- a/Sources/SwiftBSON/ByteBuffer+BSON.swift
+++ b/Sources/SwiftBSON/ByteBuffer+BSON.swift
@@ -33,6 +33,7 @@ extension ByteBuffer {
         throw BSONError.InternalError(message: "Failed to read CString, possibly missing null terminator?")
     }
 }
+
 extension String {
     internal var isValidCString: Bool {
         // C strings cannot contain embedded null bytes.

--- a/Sources/SwiftBSON/ByteBuffer+BSON.swift
+++ b/Sources/SwiftBSON/ByteBuffer+BSON.swift
@@ -5,7 +5,9 @@ extension ByteBuffer {
     @discardableResult
     internal mutating func writeCString(_ string: String) throws -> Int {
         guard string.isValidCString else {
-            throw BSONError.InvalidArgumentError(message: "C string cannot contain embedded null bytes - found \"\(string)\"")
+            throw BSONError.InvalidArgumentError(
+                message: "C string cannot contain embedded null bytes - found \"\(string)\""
+            )
         }
         let written = self.writeString(string + "\0")
         return written

--- a/Sources/SwiftBSON/ByteBuffer+BSON.swift
+++ b/Sources/SwiftBSON/ByteBuffer+BSON.swift
@@ -3,7 +3,10 @@ import NIO
 extension ByteBuffer {
     /// Write null terminated UTF-8 string to ByteBuffer starting at writerIndex
     @discardableResult
-    internal mutating func writeCString(_ string: String) -> Int {
+    internal mutating func writeCString(_ string: String) throws -> Int {
+        guard string.isValidCString else {
+            throw BSONError.InvalidArgumentError(message: "C string cannot contain embedded null bytes - found \"\(string)\"")
+        }
         let written = self.writeString(string + "\0")
         return written
     }
@@ -26,5 +29,11 @@ extension ByteBuffer {
             string.append(b)
         }
         throw BSONError.InternalError(message: "Failed to read CString, possibly missing null terminator?")
+    }
+}
+extension String {
+    internal var isValidCString: Bool {
+        // C strings cannot contain embedded null bytes.
+        !self.utf8.contains(0)
     }
 }

--- a/Sources/SwiftBSON/ExtendedJSONDecoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONDecoder.swift
@@ -169,7 +169,7 @@ public class ExtendedJSONDecoder {
                 bytes += try self.appendObject(obj, to: &storage, keyPath: keyPath)
                 return bytes
             }
-        // This can happen if an invalid C string is found as a key in the JSON.
+            // This can happen if an invalid C string is found as a key in the JSON.
         } catch let err as BSONError.InvalidArgumentError {
             throw DecodingError._extendedJSONError(keyPath: keyPath, debugDescription: err.message)
         }

--- a/Sources/SwiftBSON/ExtendedJSONDecoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONDecoder.swift
@@ -153,7 +153,12 @@ public class ExtendedJSONDecoder {
                 bytes += try storage.buildDocument { storage in
                     var bytes = 0
                     for (i, v) in arr.enumerated() {
-                        bytes += try self.appendElement(v, to: &storage, forKey: String(i), keyPath: keyPath + [String(i)])
+                        bytes += try self.appendElement(
+                            v,
+                            to: &storage,
+                            forKey: String(i),
+                            keyPath: keyPath + [String(i)]
+                        )
                     }
                     return bytes
                 }

--- a/Tests/Specs/bson-corpus/code.json
+++ b/Tests/Specs/bson-corpus/code.json
@@ -20,48 +20,48 @@
         },
         {
             "description": "two-byte UTF-8 (\u00e9)",
-            "canonical_bson": "190000000261000D000000C3A9C3A9C3A9C3A9C3A9C3A90000",
-            "canonical_extjson": "{\"a\" : \"\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\"}"
+            "canonical_bson": "190000000D61000D000000C3A9C3A9C3A9C3A9C3A9C3A90000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\\u00e9\"}}"
         },
         {
             "description": "three-byte UTF-8 (\u2606)",
-            "canonical_bson": "190000000261000D000000E29886E29886E29886E298860000",
-            "canonical_extjson": "{\"a\" : \"\\u2606\\u2606\\u2606\\u2606\"}"
+            "canonical_bson": "190000000D61000D000000E29886E29886E29886E298860000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"\\u2606\\u2606\\u2606\\u2606\"}}"
         },
         {
             "description": "Embedded nulls",
-            "canonical_bson": "190000000261000D0000006162006261620062616261620000",
-            "canonical_extjson": "{\"a\" : \"ab\\u0000bab\\u0000babab\"}"
+            "canonical_bson": "190000000D61000D0000006162006261620062616261620000",
+            "canonical_extjson": "{\"a\" : {\"$code\" : \"ab\\u0000bab\\u0000babab\"}}"
         }
     ],
     "decodeErrors": [
         {
             "description": "bad code string length: 0 (but no 0x00 either)",
-            "bson": "0C0000000261000000000000"
+            "bson": "0C0000000D61000000000000"
         },
         {
             "description": "bad code string length: -1",
-            "bson": "0C000000026100FFFFFFFF00"
+            "bson": "0C0000000D6100FFFFFFFF00"
         },
         {
             "description": "bad code string length: eats terminator",
-            "bson": "10000000026100050000006200620000"
+            "bson": "100000000D6100050000006200620000"
         },
         {
             "description": "bad code string length: longer than rest of document",
-            "bson": "120000000200FFFFFF00666F6F6261720000"
+            "bson": "120000000D00FFFFFF00666F6F6261720000"
         },
         {
             "description": "code string is not null-terminated",
-            "bson": "1000000002610004000000616263FF00"
+            "bson": "100000000D610004000000616263FF00"
         },
         {
             "description": "empty code string, but extra null",
-            "bson": "0E00000002610001000000000000"
+            "bson": "0E0000000D610001000000000000"
         },
         {
             "description": "invalid UTF-8",
-            "bson": "0E00000002610002000000E90000"
+            "bson": "0E0000000D610002000000E90000"
         }
     ]
 }

--- a/Tests/Specs/bson-corpus/document.json
+++ b/Tests/Specs/bson-corpus/document.json
@@ -51,6 +51,10 @@
         {
             "description": "Invalid subdocument: bad string length in field",
             "bson": "1C00000003666F6F001200000002626172000500000062617A000000"
+        },
+        {
+            "description": "Null byte in sub-document key",
+            "bson": "150000000378000D00000010610000010000000000"
         }
     ]
 }

--- a/Tests/Specs/bson-corpus/regex.json
+++ b/Tests/Specs/bson-corpus/regex.json
@@ -54,11 +54,11 @@
     ],
     "decodeErrors": [
         {
-            "description": "embedded null in pattern",
+            "description": "Null byte in pattern string",
             "bson": "0F0000000B610061006300696D0000"
         },
         {
-            "description": "embedded null in flags",
+            "description": "Null byte in flags string",
             "bson": "100000000B61006162630069006D0000"
         }
     ]

--- a/Tests/Specs/bson-corpus/symbol.json
+++ b/Tests/Specs/bson-corpus/symbol.json
@@ -50,31 +50,31 @@
     "decodeErrors": [
         {
             "description": "bad symbol length: 0 (but no 0x00 either)",
-            "bson": "0C0000000261000000000000"
+            "bson": "0C0000000E61000000000000"
         },
         {
             "description": "bad symbol length: -1",
-            "bson": "0C000000026100FFFFFFFF00"
+            "bson": "0C0000000E6100FFFFFFFF00"
         },
         {
             "description": "bad symbol length: eats terminator",
-            "bson": "10000000026100050000006200620000"
+            "bson": "100000000E6100050000006200620000"
         },
         {
             "description": "bad symbol length: longer than rest of document",
-            "bson": "120000000200FFFFFF00666F6F6261720000"
+            "bson": "120000000E00FFFFFF00666F6F6261720000"
         },
         {
             "description": "symbol is not null-terminated",
-            "bson": "1000000002610004000000616263FF00"
+            "bson": "100000000E610004000000616263FF00"
         },
         {
             "description": "empty symbol, but extra null",
-            "bson": "0E00000002610001000000000000"
+            "bson": "0E0000000E610001000000000000"
         },
         {
             "description": "invalid UTF-8",
-            "bson": "0E00000002610002000000E90000"
+            "bson": "0E0000000E610002000000E90000"
         }
     ]
 }

--- a/Tests/Specs/bson-corpus/top.json
+++ b/Tests/Specs/bson-corpus/top.json
@@ -79,6 +79,10 @@
         {
             "description": "Document truncated mid-key",
             "bson": "1200000002666F"
+        },
+        {
+            "description": "Null byte in document key",
+            "bson": "0D000000107800000100000000"
         }
     ],
     "parseErrors": [
@@ -92,11 +96,11 @@
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",
@@ -241,7 +245,22 @@
         {
             "description": "Bad DBpointer (extra field)",
             "string": "{\"a\": {\"$dbPointer\": {\"a\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"56e1fc72e0c917e9c4714161\"}, \"c\": {\"$numberInt\": \"2\"}, \"$ref\": \"b\"}}}"
+        },
+        {
+            "description" : "Null byte in document key",
+            "string" : "{\"a\\u0000\": 1 }"
+        },
+        {
+            "description" : "Null byte in sub-document key",
+            "string" : "{\"a\" : {\"b\\u0000\": 1 }}"
+        },
+        {
+            "description": "Null byte in $regularExpression pattern",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\\u0000\", \"options\" : \"i\"}}}"
+        },
+        {
+            "description": "Null byte in $regularExpression options",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\", \"options\" : \"i\\u0000\"}}}"
         }
-
     ]
 }

--- a/Tests/SwiftBSONTests/BSONCorpusTests.swift
+++ b/Tests/SwiftBSONTests/BSONCorpusTests.swift
@@ -365,13 +365,15 @@ final class BSONCorpusTests: BSONTestCase {
         {"r": {"$regularExpression": {"pattern": "a\\u0000", "options": ""}}}
         """.data(using: .utf8)!
 
-        expect(try ExtendedJSONDecoder().decode(Test.self, from: extJSON)).to(throwError(errorType: DecodingError.self))
+        expect(try ExtendedJSONDecoder().decode(Test.self, from: extJSON))
+            .to(throwError(errorType: DecodingError.self))
 
         // decoding invalid options from extJSON directly to a Codable type (to document is covered by corpus)
         let extJSON2 = """
         {"r": {"$regularExpression": {"pattern": "a", "options": "a\\u0000"}}}
         """.data(using: .utf8)!
 
-        expect(try ExtendedJSONDecoder().decode(Test.self, from: extJSON2)).to(throwError(errorType: DecodingError.self))
+        expect(try ExtendedJSONDecoder().decode(Test.self, from: extJSON2))
+            .to(throwError(errorType: DecodingError.self))
     }
 }


### PR DESCRIPTION
I did some more re-running of the benchmarks and got the following results:

* JSON to BSON: flat ~5% slower; deep ~7% slower; full  ~10% slower, multi-import ~8% slower
* native to BSON: flat no change, deep ~10% slower, full no change
* runCommand, findOne, insertOne varied across runs, occasionally getting both faster and slower with differences in the range of 1-3%...

For some other benchmarks which do not even touch the new `isValidCString` code, I actually saw both slight speedups and slight slowdowns (like <= 5% change)... I think those can probably just be chalked up to inconsistency on the spawn hosts. 

These numbers do not sound great, but revisiting the scope for the recent BSON performance project, compared to the scope of the performance hits we accepted there (300% slower for JSON to BSON, 25% slower for native to BSON) I don't think these are catastrophic. At the end of the day there is no way around doing this validation so I think we ought to go ahead as-is and if perf comes up as an issue for our users we can revisit and look for other ways to speed up the library.

In summary, what has changed here:
* Synced BSON corpus tests and added new prose tests
* The method we use to encode a C string to a `ByteBuffer`, `writeCString`, now validates there are no embedded null bytes before writing
* As a result of the previous bullet, a number of internal methods now `throw`, hence the number of new `try`s inserted throughout the code
* As a result of the previous bullet, we have to do some new do/catch-ing in places we call those internal methods but are not allowed to throw
* When initializing a `BSONRegularExpression` from JSON, we validate that the pattern and options are valid C strings