### PR TITLE
Make necessary changes to build and test the library on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "swift-bson",
     platforms: [
-        .macOS(.v10_14)
+        .macOS(.v10_14),
+        .iOS(.v11)
     ],
     products: [
         .library(name: "SwiftBSON", targets: ["SwiftBSON"])

--- a/Tests/SwiftBSONTests/BSONTests.swift
+++ b/Tests/SwiftBSONTests/BSONTests.swift
@@ -6,19 +6,15 @@ import SwiftBSON
 import XCTest
 
 open class BSONTestCase: XCTestCase {
-    /// Gets the path of the directory containing spec files, depending on whether
-    /// we're running from XCode or the command line
+    /// Gets the path of the directory containing spec files.
     static var specsPath: String {
-        // if we can access the "/Tests" directory, assume we're running from command line
-        if FileManager.default.fileExists(atPath: "./Tests") {
-            return "./Tests/Specs"
-        }
-        // otherwise we're in Xcode, get the bundle's resource path
-        guard let path = Bundle(for: self).resourcePath else {
-            XCTFail("Missing resource path")
-            return ""
-        }
-        return path
+        // Approach taken from https://stackoverflow.com/a/58034307
+        // TODO: SWIFT-1442 Once we drop Swift < 5.3 we can switch to including the JSON files as Resources via our
+        // package manifest instead.
+        let thisFile = URL(fileURLWithPath: #file)
+        // We are in Tests/SwiftBSONTests/BSONTests.swift; drop 2 components to get up to the Tests directory.
+        let baseDirectory = thisFile.deletingLastPathComponent().deletingLastPathComponent()
+        return baseDirectory.appendingPathComponent("Specs").path
     }
 
     // indicates whether we are running on a 32-bit platform

--- a/Tests/SwiftBSONTests/LeakCheckTests.swift
+++ b/Tests/SwiftBSONTests/LeakCheckTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS) // the Process APIs used do not exist on iOS, and `leaks` does not exist on Linux.
 import Foundation
 
 final class LeakCheckTests: BSONTestCase {
@@ -32,3 +33,4 @@ final class LeakCheckTests: BSONTestCase {
         }
     }
 }
+#endif


### PR DESCRIPTION
These changes allow the library to build and tested on iOS, either directly in Xcode or from the command line using `xcodebuild`.