### PR TITLE
SWIFT-1500, SWIFT-1501: Set minimum iOS version and expand iOS testing

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test-iOS:
-    name: Build and Test on iOS
+    name: Build and Test on iOS ${{ matrix.iOS-version }}
     runs-on: macos-11
     strategy:
       fail-fast: false
@@ -16,13 +16,13 @@ jobs:
         include:
           - xcode-version: "13.2.1"
             iOS-version: "15.2"
-            name: "iPhone 13"
+            device-name: "iPhone 13"
           - xcode-version: "12.5.1"
             iOS-version: "14.5"
-            name: "iPhone 12"
+            device-name: "iPhone 12"
           - xcode-version: "11.7"
             iOS-version: "13.7"
-            name: "iPhone 11"
+            device-name: "iPhone 11"
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          xcodebuild build-for-testing -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.name }}"
+          xcodebuild build-for-testing -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.device-name }}"
       - name: Test
         run: |
-          xcodebuild test-without-building -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.name }}"
+          xcodebuild test-without-building -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.device-name }}"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-name: iOS starter workflow
+name: iOS
 
 on:
   push:
@@ -7,16 +7,32 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-and-test-iOS:
     name: Build and Test on iOS
-    runs-on: macos-latest
+    runs-on: macos-11
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode-version: "13.2.1"
+            iOS-version: "15.2"
+            name: "iPhone 13"
+          - xcode-version: "12.5.1"
+            iOS-version: "14.5"
+            name: "iPhone 12"
+          - xcode-version: "11.7"
+            iOS-version: "13.7"
+            name: "iPhone 11"
 
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode-version }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
         run: |
-          xcodebuild build-for-testing -scheme "swift-bson" -destination "platform=iOS Simulator,name=iPhone 13"
+          xcodebuild build-for-testing -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.name }}"
       - name: Test
         run: |
-          xcodebuild test-without-building -scheme "swift-bson" -destination "platform=iOS Simulator,name=iPhone 13"
+          xcodebuild test-without-building -scheme "swift-bson" -destination "OS=${{ matrix.iOS-version }},name=${{ matrix.name }}"

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "swift-bson",
     platforms: [
         .macOS(.v10_14),
-        .iOS(.v11)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "SwiftBSON", targets: ["SwiftBSON"])


### PR DESCRIPTION
Sets the minimum iOS version for the library to iOS 13, and updates our GH Actions workflow to test on each supported iOS version.

The updated workflow file here applies to what was run for this PR, so you can see the generated tasks that way.

To choose the exact Xcode versions I referenced this [documentation](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#installed-sdks) which shows which iOS simulators are available with each Xcode version, and just went with the latest Xcode + latest iOS patch for each of iOS 13, 14, and 15. 

This implicitly has us test with the corresponding Swift versions that shipped with each of those Xcode versions, which is 5.5.2, 5.4.2, and 5.2.4 respectively. 

From a brief survey of other libraries supporting iOS (Realm, RxSwift, AlamoFire, Nimble), it doesn't seem to be common practice to try to test multiple Swift versions across single iOS versions, so for now I figured this would probably be sufficient coverage and we didn't need to bother with e.g. trying to test every Swift version the library supports across every iOS version we support.