### PR TITLE
SWIFT-1528 Omitting Options for `BSONRegularExpression`

### DIFF
--- a/Sources/SwiftBSON/BSONRegularExpression.swift
+++ b/Sources/SwiftBSON/BSONRegularExpression.swift
@@ -43,7 +43,7 @@ public struct BSONRegularExpression: Equatable, Hashable {
     public let options: String
 
     /// Initializes a new `BSONRegularExpression` with the provided pattern and options.
-    public init(pattern: String, options: String) {
+    public init(pattern: String, options: String = "") {
         self.pattern = pattern
         self.options = String(options.sorted())
     }


### PR DESCRIPTION
SWIFT-1528

Modifies the String initializer with a default value of empty string for the options parameter 