### PR TITLE
SWIFT-1508 Conform BSONTimestamp to Comparable

### DIFF
--- a/Sources/SwiftBSON/BSONTimestamp.swift
+++ b/Sources/SwiftBSON/BSONTimestamp.swift
@@ -91,9 +91,8 @@ public struct BSONTimestamp: BSONValue, Comparable, Equatable, Hashable {
         ]
     }
 
-    /// Compares two `BSONTimestamp` values as outlined by the Comparable protocol
+    /// Compares two `BSONTimestamp` instances as outlined by the Comparable protocol
     public static func < (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
-        // If ts same move onto comparabel
         if lhs.timestamp != rhs.timestamp {
             return lhs.timestamp < rhs.timestamp
         } else { // equal timestamps, look at increment
@@ -101,9 +100,9 @@ public struct BSONTimestamp: BSONValue, Comparable, Equatable, Hashable {
         }
     }
 
-    /// Checks two `BSONTimestamp`s for equality as outlined by the Comparable protocol
+    /// Checks two `BSONTimestamp` instances for equality as outlined by the Comparable protocol
     public static func == (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
-        lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
+        return lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
     }
 
     internal static func read(from buffer: inout ByteBuffer) throws -> BSON {

--- a/Sources/SwiftBSON/BSONTimestamp.swift
+++ b/Sources/SwiftBSON/BSONTimestamp.swift
@@ -3,7 +3,9 @@ import NIO
 /// A struct to represent the BSON Timestamp type. This type is for internal MongoDB use. For most cases, in
 /// application development, you should use the BSON date type (represented in this library by `Date`.)
 /// - SeeAlso: https://docs.mongodb.com/manual/reference/bson-types/#timestamps
-public struct BSONTimestamp: BSONValue, Equatable, Hashable {
+public struct BSONTimestamp: BSONValue, Comparable, Equatable, Hashable {
+    
+    
     internal static let extJSONTypeWrapperKeys: [String] = ["$timestamp"]
     internal static var bsonType: BSONType { .timestamp }
     internal var bson: BSON { .timestamp(self) }
@@ -89,6 +91,21 @@ public struct BSONTimestamp: BSONValue, Equatable, Hashable {
                 "i": JSON(.number(String(self.increment)))
             ]
         ]
+    }
+    
+    /// Compares two `BSONTimestamp` values as outlined by the Comparable protocol
+    public static func < (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
+        //If ts same move onto comparabel
+        if (lhs.timestamp != rhs.timestamp){
+            return lhs.timestamp < rhs.timestamp
+        } else { //equal timestamps, look at increment
+            return lhs.increment < rhs.increment
+        }
+    }
+    
+    /// Checks two `BSONTimestamp`s for equality as outlined by the Comparable protocol
+    public static func == (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
+        return lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
     }
 
     internal static func read(from buffer: inout ByteBuffer) throws -> BSON {

--- a/Sources/SwiftBSON/BSONTimestamp.swift
+++ b/Sources/SwiftBSON/BSONTimestamp.swift
@@ -4,8 +4,6 @@ import NIO
 /// application development, you should use the BSON date type (represented in this library by `Date`.)
 /// - SeeAlso: https://docs.mongodb.com/manual/reference/bson-types/#timestamps
 public struct BSONTimestamp: BSONValue, Comparable, Equatable, Hashable {
-    
-    
     internal static let extJSONTypeWrapperKeys: [String] = ["$timestamp"]
     internal static var bsonType: BSONType { .timestamp }
     internal var bson: BSON { .timestamp(self) }
@@ -92,20 +90,20 @@ public struct BSONTimestamp: BSONValue, Comparable, Equatable, Hashable {
             ]
         ]
     }
-    
+
     /// Compares two `BSONTimestamp` values as outlined by the Comparable protocol
     public static func < (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
-        //If ts same move onto comparabel
-        if (lhs.timestamp != rhs.timestamp){
+        // If ts same move onto comparabel
+        if lhs.timestamp != rhs.timestamp {
             return lhs.timestamp < rhs.timestamp
-        } else { //equal timestamps, look at increment
+        } else { // equal timestamps, look at increment
             return lhs.increment < rhs.increment
         }
     }
-    
+
     /// Checks two `BSONTimestamp`s for equality as outlined by the Comparable protocol
     public static func == (lhs: BSONTimestamp, rhs: BSONTimestamp) -> Bool {
-        return lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
+        lhs.timestamp == rhs.timestamp && lhs.increment == rhs.increment
     }
 
     internal static func read(from buffer: inout ByteBuffer) throws -> BSON {

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -373,8 +373,8 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             .to(throwError(errorType: DecodingError.self))
         expect(try BSONTimestamp(fromExtJSON: ["$timestamp": ["t": 1, "i": 2], "extra": "2"], keyPath: []))
             .to(throwError(errorType: DecodingError.self))
-        
-        //Comparable testing
+
+        // Comparable testing
         let base = BSONTimestamp(timestamp: 6, inc: 5)
         let compare1 = BSONTimestamp(timestamp: 7, inc: 5)
         let compare2 = BSONTimestamp(timestamp: 6, inc: 6)

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -373,6 +373,15 @@ open class ExtendedJSONConversionTestCase: BSONTestCase {
             .to(throwError(errorType: DecodingError.self))
         expect(try BSONTimestamp(fromExtJSON: ["$timestamp": ["t": 1, "i": 2], "extra": "2"], keyPath: []))
             .to(throwError(errorType: DecodingError.self))
+        
+        //Comparable testing
+        let base = BSONTimestamp(timestamp: 6, inc: 5)
+        let compare1 = BSONTimestamp(timestamp: 7, inc: 5)
+        let compare2 = BSONTimestamp(timestamp: 6, inc: 6)
+        let compare3 = BSONTimestamp(timestamp: 6, inc: 5)
+        expect(base < compare1).to(beTrue())
+        expect(base < compare2).to(beTrue())
+        expect(base == compare3).to(beTrue())
     }
 
     func testRegularExpression() throws {


### PR DESCRIPTION
Adds adherence of the `BSONTimestamp` type to the `Comparable` Protocol by implementing the < and == operator functions as defined [here](https://developer.apple.com/documentation/swift/comparable). Also modifies the `testTimestamp()` case to compare two instances of `BSONTimestamp` in addition to extended JSON testing