### PR TITLE
NIO dependency change to NIOCore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0"))
     ],
     targets: [
-        .target(name: "SwiftBSON", dependencies: ["NIO", "ExtrasJSON", "ExtrasBase64"]),
+        .target(name: "SwiftBSON", dependencies: ["NIOCore", "ExtrasJSON", "ExtrasBase64"]),
         .testTarget(name: "SwiftBSONTests", dependencies: ["SwiftBSON", "Nimble", "ExtrasJSON"])
     ]
 )

--- a/Sources/SwiftBSON/Array+BSONValue.swift
+++ b/Sources/SwiftBSON/Array+BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// An extension of `Array` to represent the BSON array type.
 extension Array: BSONValue where Element == BSON {

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -1,7 +1,7 @@
 import ExtrasBase64
 import ExtrasJSON
 import Foundation
-import NIO
+import NIOCore
 
 /// A struct to represent the BSON Binary type.
 public struct BSONBinary: Equatable, Hashable {

--- a/Sources/SwiftBSON/BSONCode.swift
+++ b/Sources/SwiftBSON/BSONCode.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A struct to represent the BSON Code type.
 public struct BSONCode: Equatable, Hashable {

--- a/Sources/SwiftBSON/BSONDBPointer.swift
+++ b/Sources/SwiftBSON/BSONDBPointer.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A struct to represent the deprecated DBPointer type.
 /// DBPointers cannot be instantiated, but they can be read from existing documents that contain them.

--- a/Sources/SwiftBSON/BSONDecimal128.swift
+++ b/Sources/SwiftBSON/BSONDecimal128.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 private extension UInt64 {
     var upper32bits: Self { self.getBits(0...31) }

--- a/Sources/SwiftBSON/BSONDocument.swift
+++ b/Sources/SwiftBSON/BSONDocument.swift
@@ -1,6 +1,6 @@
 import ExtrasJSON
 import Foundation
-import NIO
+import NIOCore
 
 /// This shared allocator instance should be used for all underlying `ByteBuffer` creation.
 internal let BSON_ALLOCATOR = ByteBufferAllocator()

--- a/Sources/SwiftBSON/BSONDocumentIterator.swift
+++ b/Sources/SwiftBSON/BSONDocumentIterator.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 /// :nodoc:
 /// Iterator over a `BSONDocument`. This type is not meant to be used directly; please use `Sequence` protocol methods

--- a/Sources/SwiftBSON/BSONEncoder.swift
+++ b/Sources/SwiftBSON/BSONEncoder.swift
@@ -1,6 +1,6 @@
 import ExtrasBase64
 import Foundation
-import NIO
+import NIOCore
 
 /// `BSONEncoder` facilitates the encoding of `Encodable` values into BSON.
 public class BSONEncoder {

--- a/Sources/SwiftBSON/BSONError.swift
+++ b/Sources/SwiftBSON/BSONError.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 /// An empty protocol for encapsulating all errors that BSON package can throw.
 public protocol BSONErrorProtocol: LocalizedError {}

--- a/Sources/SwiftBSON/BSONNulls.swift
+++ b/Sources/SwiftBSON/BSONNulls.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A struct to represent the BSON null type.
 internal struct BSONNull: BSONValue, Equatable {

--- a/Sources/SwiftBSON/BSONObjectID.swift
+++ b/Sources/SwiftBSON/BSONObjectID.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 import NIOConcurrencyHelpers
 
 /// A struct to represent the BSON ObjectID type.

--- a/Sources/SwiftBSON/BSONRegularExpression.swift
+++ b/Sources/SwiftBSON/BSONRegularExpression.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 // A mapping of regex option characters to their equivalent `NSRegularExpression` option.
 // note that there is a BSON regexp option 'l' that `NSRegularExpression`

--- a/Sources/SwiftBSON/BSONSymbol.swift
+++ b/Sources/SwiftBSON/BSONSymbol.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A struct to represent the deprecated Symbol type.
 /// Symbols cannot be instantiated, but they can be read from existing documents that contain them.

--- a/Sources/SwiftBSON/BSONTimestamp.swift
+++ b/Sources/SwiftBSON/BSONTimestamp.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 /// A struct to represent the BSON Timestamp type. This type is for internal MongoDB use. For most cases, in
 /// application development, you should use the BSON date type (represented in this library by `Date`.)

--- a/Sources/SwiftBSON/BSONValue.swift
+++ b/Sources/SwiftBSON/BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 internal protocol BSONValue: Codable, BSONRepresentable {
     /// The `BSONType` associated with this value.

--- a/Sources/SwiftBSON/Bool+BSONValue.swift
+++ b/Sources/SwiftBSON/Bool+BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension Bool: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = []

--- a/Sources/SwiftBSON/ByteBuffer+BSON.swift
+++ b/Sources/SwiftBSON/ByteBuffer+BSON.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension ByteBuffer {
     /// Write null terminated UTF-8 string to ByteBuffer starting at writerIndex

--- a/Sources/SwiftBSON/Date+BSONValue.swift
+++ b/Sources/SwiftBSON/Date+BSONValue.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NIO
+import NIOCore
 
 extension Date: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = ["$date"]

--- a/Sources/SwiftBSON/Double+BSONValue.swift
+++ b/Sources/SwiftBSON/Double+BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension Double: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = ["$numberDouble"]

--- a/Sources/SwiftBSON/ExtendedJSONDecoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONDecoder.swift
@@ -1,6 +1,6 @@
 import ExtrasJSON
 import Foundation
-import NIO
+import NIOCore
 
 /// `ExtendedJSONDecoder` facilitates the decoding of ExtendedJSON into `Decodable` values.
 public class ExtendedJSONDecoder {

--- a/Sources/SwiftBSON/ExtendedJSONEncoder.swift
+++ b/Sources/SwiftBSON/ExtendedJSONEncoder.swift
@@ -1,6 +1,6 @@
 import ExtrasJSON
 import Foundation
-import NIO
+import NIOCore
 
 /// Facilitates the encoding of `Encodable` values into ExtendedJSON.
 public class ExtendedJSONEncoder {

--- a/Sources/SwiftBSON/Integers+BSONValue.swift
+++ b/Sources/SwiftBSON/Integers+BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension Int32: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = ["$numberInt"]

--- a/Sources/SwiftBSON/String+BSONValue.swift
+++ b/Sources/SwiftBSON/String+BSONValue.swift
@@ -1,4 +1,4 @@
-import NIO
+import NIOCore
 
 extension String: BSONValue {
     internal static let extJSONTypeWrapperKeys: [String] = []

--- a/Tests/SwiftBSONTests/BSONTests.swift
+++ b/Tests/SwiftBSONTests/BSONTests.swift
@@ -1,7 +1,7 @@
 import ExtrasJSON
 import Foundation
 import Nimble
-import NIO
+import NIOCore
 import SwiftBSON
 import XCTest
 

--- a/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
+++ b/Tests/SwiftBSONTests/ExtendedJSONConversionTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Nimble
-import NIO
+import NIOCore
 @testable import SwiftBSON
 import XCTest
 

--- a/Tests/SwiftBSONTests/JSONTests.swift
+++ b/Tests/SwiftBSONTests/JSONTests.swift
@@ -1,7 +1,7 @@
 import ExtrasJSON
 import Foundation
 import Nimble
-import NIO
+import NIOCore
 @testable import SwiftBSON
 import XCTest
 


### PR DESCRIPTION
swift-bson doesn't seem to have to rely on all modules in NIO

- NIO dependency change to NIOCore
- import NIO change to import NIOCore