### PR TITLE
SWIFT-1337 drop Swift 5.1 support 

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -66,6 +66,26 @@ functions:
       params:
         working_dir: "src"
         script: |
+          set -o xtrace
+          set -o errexit
+
+          if [ "${SWIFT_MINOR_VERSION}" = "main-snapshot" ]; then
+              export SWIFT_VERSION="${SWIFT_MINOR_VERSION}"
+          else
+              # otherwise, find the latest patch release for the specified version
+              ${PYTHON} -m virtualenv ./requests-env
+              ./requests-env/${VENV_BIN_DIR}/python3 -m pip install requests
+              export SWIFT_VERSION="$(./requests-env/${VENV_BIN_DIR}/python3 .evergreen/get_latest_swift_patch.py ${SWIFT_MINOR_VERSION})"
+          fi
+          echo "SWIFT_VERSION: $SWIFT_VERSION" > swift-version.yml
+          cat swift-version.yml
+    - command: expansions.update
+      params:
+        file: src/swift-version.yml
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
           ${PREPARE_SHELL}
           SWIFT_VERSION=${SWIFT_VERSION} \
             sh ${PROJECT_DIRECTORY}/.evergreen/install-swift.sh
@@ -136,42 +156,50 @@ axes:
       - id: ubuntu-18.04
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
+          VENV_BIN_DIR: "bin"
 
       - id: ubuntu-20.04
         display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
+          VENV_BIN_DIR: "bin"
+      
+      - id: macos-10.14
+        display_name: "macOS 10.14"
+        run_on: macos-1014
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
+          VENV_BIN_DIR: "bin"
 
-      - id: macos-10.15
-        display_name: "macOS 10.15"
-        run_on: macos-1015
+      - id: macos-11
+        display_name: "macOS 11"
+        run_on: macos-1100
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
+          VENV_BIN_DIR: "bin"
 
   - id: swift-version
     display_name: "Swift"
     values:
-      - id: "5.1"
-        display_name: "Swift 5.1"
-        variables:
-          SWIFT_VERSION: "5.1.5"
       - id: "5.2"
         display_name: "Swift 5.2"
         variables:
-          SWIFT_VERSION: "5.2.5"
-      - id: "5.3"
-        display_name: "Swift 5.3"
-        variables:
-          SWIFT_VERSION: "5.3.3"
-      - id: "5.4"
-        display_name: "Swift 5.4"
-        variables:
-          SWIFT_VERSION: "5.4.2"
+          SWIFT_MINOR_VERSION: "5.2"
       - id: "5.5"
         display_name: "Swift 5.5"
         variables:
-          SWIFT_VERSION: "5.5"
-      - id: "6.0-dev"
-        display_name: "Swift 6.0-dev"
+          SWIFT_MINOR_VERSION: "5.5"
+      - id: "5.6"
+        display_name: "Swift 5.6"
         variables:
-          SWIFT_VERSION: "main-snapshot"
+          SWIFT_MINOR_VERSION: "5.6"
+      - id: "5.7-dev"
+        display_name: "Swift 5.7-dev"
+        variables:
+          SWIFT_MINOR_VERSION: "main-snapshot"
 
   - id: sanitize
     display_name: Sanitize
@@ -196,28 +224,31 @@ axes:
           CHECK_LEAKS: leaks
 
 buildvariants:
-  # test two latest stable releases, plus latest dev snapshots
+  # test two latest stable releases plus latest dev snapshots
   - matrix_name: "tests-all"
     display_name: "${swift-version} ${os-fully-featured}"
     matrix_spec:
-      os-fully-featured: "*"
+      os-fully-featured:
+        - "macos-11"
+        - "ubuntu-20.04"
+        - "ubuntu-18.04"
       swift-version:
-        - "5.4"
         - "5.5"
-        - "6.0-dev"
+        - "5.6"
+        - "5.7-dev"
     tasks:
       - name: "test"
-
-  # test our lowest supported version
-  - matrix_name: "tests-5.1"
+    
+  # test minimum supported version
+  - matrix_name: "tests-min-version"
     display_name: "${swift-version} ${os-fully-featured}"
     matrix_spec:
-      # Swift 5.1 does not have Ubuntu 20.04 toolchains
       os-fully-featured:
+        - "macos-10.14"
+        - "ubuntu-20.04"
         - "ubuntu-18.04"
-        - "macos-10.15"
       swift-version:
-        - "5.1"
+        - "5.2"
     tasks:
       - name: "test"
 
@@ -225,7 +256,7 @@ buildvariants:
     display_name: "Format and Lint"
     matrix_spec:
       os-fully-featured: "ubuntu-18.04"
-      swift-version: "5.4" # updating to 5.5 blocked on a SwiftLint release > 0.44
+      swift-version: "5.6"
     tasks:
       - name: "check-format"
       - name: "check-lint"
@@ -234,7 +265,7 @@ buildvariants:
     display_name: "${sanitize} ${os-fully-featured}"
     matrix_spec:
       os-fully-featured: "ubuntu-18.04"
-      swift-version: "5.5"
+      swift-version: "5.6"
       sanitize: "tsan"
     tasks:
       - name: "test"
@@ -242,8 +273,8 @@ buildvariants:
   - matrix_name: "leaks"
     display_name: "Leak Checker ${os-fully-featured}"
     matrix_spec:
-      os-fully-featured: "macos-10.15"
-      swift-version: "5.5"
+      os-fully-featured: "macos-11"
+      swift-version: "5.6"
       check-leaks: "leaks"
     tasks:
       - name: "test"

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -22,11 +22,10 @@ if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
 fi
 
 if [ "$OS" == "darwin" ]; then
-    # 5.1, 5.2 require an older version of Xcode/Command Line Tools
-    if [[ "$SWIFT_VERSION" == 5.1.* || "$SWIFT_VERSION" == 5.2.* ]]; then
+    if [[ "$SWIFT_VERSION" == 5.2.* ]]; then
         sudo xcode-select -s /Applications/Xcode11.3.app
     else
-        sudo xcode-select -s /Applications/Xcode12.app
+        sudo xcode-select -s /Applications/Xcode13.2.1.app
     fi
 fi
 

--- a/.evergreen/configure-swift.sh
+++ b/.evergreen/configure-swift.sh
@@ -22,6 +22,7 @@ if [ "$SWIFT_VERSION" = "main-snapshot" ]; then
 fi
 
 if [ "$OS" == "darwin" ]; then
+    # 5.2 requires an older version of Xcode/Command Line Tools
     if [[ "$SWIFT_VERSION" == 5.2.* ]]; then
         sudo xcode-select -s /Applications/Xcode11.3.app
     else

--- a/.evergreen/get_latest_swift_patch.py
+++ b/.evergreen/get_latest_swift_patch.py
@@ -1,0 +1,34 @@
+import re
+import requests
+import sys
+
+# This script accepts a version number in the form "x.y" as an argument. It will query the Swift Github
+# repo for releases and find the latest x.y.z patch release if available, and print out the matching tag.
+
+if len(sys.argv) != 2:
+    print("Expected 1 argument, but got: {}".format(sys.argv[1:]))
+    exit(1)
+
+version = sys.argv[1]
+components = version.split('.')
+if len(components) != 2:
+    print("Expected version number in form x.y, got {}".format(version))
+    exit(1)
+
+major = components[0]
+minor = components[1]
+
+version_regex = '^swift-({}\.{}(\.(\d+))?)-RELEASE$'.format(major, minor)
+
+release_data = requests.get('https://api.github.com/repos/apple/swift/releases').json()
+tag_names = map(lambda release: release['tag_name'], release_data)
+
+# find tags matching the specified regexes
+matches = filter(lambda match: match is not None, map(lambda tag: re.match(version_regex, tag), tag_names))
+
+# sort matches by their patch versions. patch versions of 0 are omitted so substitute 0 when the group is None.
+sorted_matches = sorted(matches, key=lambda match: int(match.group(2)[1:]) if match.group(2) is not None else 0, reverse=True)
+
+# map to the first match group which contains the full version number.
+sorted_version_numbers = map(lambda match: match.group(1), sorted_matches)
+print(next(sorted_version_numbers))

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,8 +19,14 @@ if [ "$SANITIZE" != "false" ]; then
     SANITIZE_STATEMENT="--sanitize ${SANITIZE}"
 fi
 
+# work around https://github.com/mattgallagher/CwlPreconditionTesting/issues/22 (bug still exists in version 1.x
+# when using Xcode 13.2)
+if [ "$OS" == "darwin" ]; then
+    EXTRA_FLAGS="-Xswiftc -Xfrontend -Xswiftc -validate-tbd-against-ir=none"
+fi
+
 # build the driver
-swift build $SANITIZE_STATEMENT
+swift build $EXTRA_FLAGS $SANITIZE_STATEMENT
 
 # even if tests fail we want to parse the results, so disable errexit
 set +o errexit
@@ -28,7 +34,7 @@ set +o errexit
 set -o pipefail
 
 # test the driver
-swift test --enable-test-discovery $SANITIZE_STATEMENT 2>&1 | tee ${RAW_TEST_RESULTS}
+swift test --enable-test-discovery $EXTRA_FLAGS $SANITIZE_STATEMENT 2>&1 | tee ${RAW_TEST_RESULTS}
 
 # save tests exit code
 EXIT_CODE=$?

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -17,7 +17,16 @@ let package = Package(
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0"))
     ],
     targets: [
-        .target(name: "SwiftBSON", dependencies: ["NIO", "ExtrasJSON", "ExtrasBase64"]),
-        .testTarget(name: "SwiftBSONTests", dependencies: ["SwiftBSON", "Nimble", "ExtrasJSON"])
+        .target(name: "SwiftBSON", dependencies: [
+            .product(name: "NIO", package: "swift-nio"),
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            .product(name: "ExtrasJSON", package: "swift-extras-json"),
+            .product(name: "ExtrasBase64", package: "swift-extras-base64")
+        ]),
+        .testTarget(name: "SwiftBSONTests", dependencies: [
+            "SwiftBSON",
+            .product(name: "Nimble", package: "Nimble"),
+            .product(name: "ExtrasJSON", package: "swift-extras-json")
+        ])
     ]
 )


### PR DESCRIPTION
SWIFT-1337

Drops Swift 5.1 support. This is a prerequisite for #85

[patch](https://spruce.mongodb.com/version/62fe7e11e3c33116292cca3b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)