### PR TITLE
SWIFT-1660 publicize [UInt8]- and ByteBuffer-taking initializers on BSONBinary

### DIFF
--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -89,12 +89,20 @@ public struct BSONBinary: Equatable, Hashable {
         self = try BSONBinary(buffer: buffer, subtype: subtype)
     }
 
+    /// Initializes a `BSONBinary` instance from a `[UInt8]` array and a `Subtype` subtype.
+    /// This will always create a copy of the array contents.
+    /// - Throws:
+    ///   - `BSONError.InvalidArgumentError` if the provided array is incompatible with the specified subtype.
     public init(bytes: [UInt8], subtype: Subtype) throws {
         var buffer = BSON_ALLOCATOR.buffer(capacity: bytes.count)
         buffer.writeBytes(bytes)
         self = try BSONBinary(buffer: buffer, subtype: subtype)
     }
 
+    /// Initializes a `BSONBinary` instance from a `ByteBuffer` and a `Subtype` subtype.
+    /// This will always create a copy of the buffer contents.
+    /// - Throws:
+    ///   - `BSONError.InvalidArgumentError` if the provided buffer is incompatible with the specified subtype.
     public init(buffer: ByteBuffer, subtype: Subtype) throws {
         if [Subtype.uuid, Subtype.uuidDeprecated].contains(subtype) && buffer.readableBytes != 16 {
             throw BSONError.InvalidArgumentError(

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -89,13 +89,13 @@ public struct BSONBinary: Equatable, Hashable {
         self = try BSONBinary(buffer: buffer, subtype: subtype)
     }
 
-    internal init(bytes: [UInt8], subtype: Subtype) throws {
+    public init(bytes: [UInt8], subtype: Subtype) throws {
         var buffer = BSON_ALLOCATOR.buffer(capacity: bytes.count)
         buffer.writeBytes(bytes)
         self = try BSONBinary(buffer: buffer, subtype: subtype)
     }
 
-    internal init(buffer: ByteBuffer, subtype: Subtype) throws {
+    public init(buffer: ByteBuffer, subtype: Subtype) throws {
         if [Subtype.uuid, Subtype.uuidDeprecated].contains(subtype) && buffer.readableBytes != 16 {
             throw BSONError.InvalidArgumentError(
                 message:

--- a/Sources/SwiftBSON/BSONBinary.swift
+++ b/Sources/SwiftBSON/BSONBinary.swift
@@ -100,7 +100,6 @@ public struct BSONBinary: Equatable, Hashable {
     }
 
     /// Initializes a `BSONBinary` instance from a `ByteBuffer` and a `Subtype` subtype.
-    /// This will always create a copy of the buffer contents.
     /// - Throws:
     ///   - `BSONError.InvalidArgumentError` if the provided buffer is incompatible with the specified subtype.
     public init(buffer: ByteBuffer, subtype: Subtype) throws {


### PR DESCRIPTION
publicizes the `[UInt8]`- and `ByteBuffer`-taking initializers on `BSONBinary`. fixes [SWIFT-1660](https://jira.mongodb.org/browse/SWIFT-1660).